### PR TITLE
Add readline support

### DIFF
--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -99,7 +99,7 @@ def run_apython_in_subprocess(args=None):
     while process.poll() is None:
         try:
             prompt = wait_for_prompt(process.stderr, sys.stderr)
-            raw = input_with_stderr_prompt(prompt) + os.linesep
+            raw = input_with_stderr_prompt(prompt) + '\n'
         except KeyboardInterrupt:
             process.send_signal(signal.SIGINT)
         except EOFError:
@@ -112,7 +112,7 @@ def run_apython_in_subprocess(args=None):
     return process.returncode
 
 
-def wait_for_prompt(src, dest, targets='.>', current=os.linesep):
+def wait_for_prompt(src, dest, targets='.>', current='\n'):
 
     # Read exactly one byte
     def read_one():
@@ -123,7 +123,7 @@ def wait_for_prompt(src, dest, targets='.>', current=os.linesep):
 
     while True:
         # Prompt detection
-        if current.endswith(os.linesep[-1]):
+        if current.endswith('\n'):
             current = reference = read_one()
             if reference in targets:
                 while current.endswith(reference):
@@ -146,7 +146,7 @@ def input_with_stderr_prompt(prompt=''):
     result = call_readline(fin, ferr, prompt.encode())
     if len(result) == 0:
         raise EOFError
-    return result.decode().rstrip(os.linesep)
+    return result.decode().rstrip('\n')
 
 
 if __name__ == '__main__':

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -1,3 +1,4 @@
+"""Provide the apython script."""
 
 import os
 import sys
@@ -10,23 +11,29 @@ import subprocess
 from . import events
 from . import server
 
-
-def parse_args(args):
-    parser = argparse.ArgumentParser(prog='apython', description='''\
+DESCRIPTION = """\
 Run the given python file or module with a modified asyncio policy replacing
 the default event loop with an interactive loop.
-If no argument is given, it simply runs an asynchronous python console.
-''')
-    parser.add_argument('--serve', '-s', metavar='[HOST:] PORT',
-                        help='serve a console on the given interface instead')
-    parser.add_argument('--module', '-m', dest='module', action='store_true',
-                        help='run a python module')
-    parser.add_argument('--no-readline', dest='readline',
-                        action='store_false', help='Force readline disabling')
-    parser.add_argument('filename', metavar='FILE', nargs='?',
-                        help='python file or module to run')
-    parser.add_argument('args', metavar='ARGS', nargs=argparse.REMAINDER,
-                        help='extra arguments')
+If no argument is given, it simply runs an asynchronous python console."""
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser(prog='apython', description=DESCRIPTION)
+    parser.add_argument(
+        '--serve', '-s', metavar='[HOST:] PORT',
+        help='serve a console on the given interface instead')
+    parser.add_argument(
+        '--module', '-m', dest='module', action='store_true',
+        help='run a python module')
+    parser.add_argument(
+        '--no-readline', dest='readline', action='store_false',
+        help='Force readline disabling')
+    parser.add_argument(
+        'filename', metavar='FILE', nargs='?',
+        help='python file or module to run')
+    parser.add_argument(
+        'args', metavar='ARGS', nargs=argparse.REMAINDER,
+        help='extra arguments')
     namespace = parser.parse_args(args)
     if namespace.module and not namespace.filename:
         parser.error('A python module is required.')
@@ -36,8 +43,6 @@ If no argument is given, it simply runs an asynchronous python console.
 
 
 def run_apython(args=None):
-    if args is None:
-        args = sys.argv[1:]
     namespace = parse_args(args)
 
     try:

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -139,11 +139,18 @@ def wait_for_prompt(src, dest, targets='.>', current='\n'):
 
 def input_with_stderr_prompt(prompt=''):
     api = ctypes.pythonapi
+    # Get standard streams
+    try:
+        fin = ctypes.c_void_p.in_dll(api, 'stdin')
+        ferr = ctypes.c_void_p.in_dll(api, 'stderr')
+    # Cygwin fallback
+    except ValueError:
+        return input(prompt)
+    # Call readline
     call_readline = api.PyOS_Readline
     call_readline.restype = ctypes.c_char_p
-    fin = ctypes.c_void_p.in_dll(api, 'stdin')
-    ferr = ctypes.c_void_p.in_dll(api, 'stderr')
     result = call_readline(fin, ferr, prompt.encode())
+    # Decode result
     if len(result) == 0:
         raise EOFError
     return result.decode().rstrip('\n')

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -17,7 +17,7 @@ Run the given python file or module with a modified asyncio policy replacing
 the default event loop with an interactive loop.
 If no argument is given, it simply runs an asynchronous python console.
 ''')
-    parser.add_argument('--serve', '-s', metavar='[HOST:]PORT',
+    parser.add_argument('--serve', '-s', metavar='[HOST:] PORT',
                         help='serve a console on the given interface instead')
     parser.add_argument('--module', '-m', dest='module', action='store_true',
                         help='run a python module')

--- a/aioconsole/code.py
+++ b/aioconsole/code.py
@@ -181,7 +181,7 @@ class AsynchronousConsole(code.InteractiveConsole):
         return more
 
     @asyncio.coroutine
-    def raw_input(self, prompt=""):
+    def raw_input(self, prompt=''):
         self.write(prompt)
         yield from self.flush()
         data = (yield from self.reader.readline())
@@ -192,7 +192,7 @@ class AsynchronousConsole(code.InteractiveConsole):
                 raise SystemExit
             data = '\n'
         if not data.endswith('\n'):
-            raise EOFError()
+            raise EOFError
         return data.rstrip('\n')
 
     def write(self, data):

--- a/aioconsole/code.py
+++ b/aioconsole/code.py
@@ -193,7 +193,7 @@ class AsynchronousConsole(code.InteractiveConsole):
             data = '\n'
         if not data.endswith('\n'):
             raise EOFError()
-        return data
+        return data.rstrip('\n')
 
     def write(self, data):
         return self.writer.write(data.encode())

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -1,6 +1,5 @@
 """Provide an asynchronous equivalent *to exec*."""
 
-import sys
 import ast
 import codeop
 import asyncio

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -1,7 +1,6 @@
 """Serve the python console using socket communication."""
 
 import asyncio
-import argparse
 
 from . import code
 
@@ -66,16 +65,3 @@ def parse_server(server, parser=None):
             raise ValueError(msg)
         parser.error(msg)
     return host, port
-
-
-def parse_args(args=None):
-    parser = argparse.ArgumentParser(
-        description="Serve the python console.")
-    parser.add_argument(
-        'server',
-        metavar='[HOST:]PORT',
-        type=str,
-        default=8000,
-        help='default is localhost:8000')
-    namespace = parser.parse_args(args)
-    return parse_server(namespace.server, parser)

--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -154,5 +154,5 @@ def ainput(prompt=None, *, loop=None):
     data = (yield from reader.readline()).decode()
     # Return or raise EOF
     if not data.endswith('\n'):
-            raise EOFError()
-    return data
+        raise EOFError
+    return data.rstrip('\n')

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,7 +109,7 @@ So we can access the ``history`` of received messages:
     >>> sum(loop.history.values(), [])
     []
 
-Let’s send a message to the server using a ``netcat`` client:
+Let’s send a message to the server using a netcat_ client:
 
 .. sourcecode:: console
 
@@ -163,11 +163,11 @@ modify the code:
     The console is being served on 0.0.0.0:8889
     The echo service is being served on 127.0.0.1:8888
 
-Then connect using ``netcat``:
+Then connect using netcat_ and optionally, rlwrap_:
 
 .. sourcecode:: console
 
-    $ nc localhost 8889
+    $ rlwrap nc localhost 8889
     Python 3.5.0 (default, Sep 7 2015, 14:12:03)
     [GCC 4.8.4] on linux
     Type "help", "copyright", "credits" or "license" for more information.
@@ -278,11 +278,11 @@ previous `example`_ provides this functionality through the
     The command line interface is being served on 127.0.0.1:8889
     The echo service is being served on 127.0.0.1:8888
 
-It’s now possible to access the interface using ``netcat``:
+It’s now possible to access the interface using netcat_:
 
 .. sourcecode:: console
 
-    $ nc localhost 8889
+    $ rlwrap nc localhost 8889
     Welcome to the CLI interface of echo!
     Try:
      * 'help' to display the help message
@@ -325,3 +325,5 @@ Vincent Michel: vxgmichel@gmail.com
 .. _slightly modified version: `example/echo.py`_
 .. _example: `example/cli.py`_
 .. _PyPI: aioconsole_
+.. _netcat: https://linux.die.net/man/1/nc
+.. _rlwrap: https://linux.die.net/man/1/rlwrap


### PR DESCRIPTION
Add readline support to the `apython` script by running the given program in a subprocess.

Also fix the multiline editing issue.

Related: issue #7 

Todo:
- [x] Fix the prompt width issue
- [x] Fix stdout/stderr inconsistency 