### PR TITLE
apython readline support on Mac OS X

### DIFF
--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -5,6 +5,7 @@ import sys
 import runpy
 import ctypes
 import signal
+import platform
 import argparse
 import subprocess
 
@@ -141,8 +142,14 @@ def input_with_stderr_prompt(prompt=''):
     api = ctypes.pythonapi
     # Get standard streams
     try:
-        fin = ctypes.c_void_p.in_dll(api, 'stdin')
-        ferr = ctypes.c_void_p.in_dll(api, 'stderr')
+        if platform.system() == 'Darwin':
+            stdin = '__stdinp'
+            stderr = '__stderrp'
+        else:
+            stdin = 'stdin'
+            stderr = 'stderr'
+        fin = ctypes.c_void_p.in_dll(api, stdin)
+        ferr = ctypes.c_void_p.in_dll(api, stderr)
     # Cygwin fallback
     except ValueError:
         raise

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -5,7 +5,6 @@ import sys
 import runpy
 import ctypes
 import signal
-import platform
 import argparse
 import subprocess
 
@@ -142,7 +141,7 @@ def input_with_stderr_prompt(prompt=''):
     api = ctypes.pythonapi
     # Get standard streams
     try:
-        if platform.system() == 'Darwin':
+        if sys.platform == 'darwin':
             stdin = '__stdinp'
             stderr = '__stderrp'
         else:

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch, call
+
+import pytest
+
+from aioconsole import apython
+
+@pytest.fixture(params=['Darwin', 'Linux'])
+def platform(request):
+    return request.param
+
+@patch('aioconsole.apython.ctypes')
+@patch('aioconsole.apython.platform')
+def test_input_with_stderr_prompt_darwin(m_platform, m_ctypes, platform):
+    m_platform.system.return_value = platform
+
+
+    if platform == 'Darwin':
+        stdin = '__stdinp'
+        stderr = '__stderrp'
+    else:
+        stdin = 'stdin'
+        stderr = 'stderr'
+
+    api = m_ctypes.pythonapi
+    call_readline = api.PyOS_Readline
+    result = call_readline.return_value
+    result.__len__.return_value = 1
+
+    apython.input_with_stderr_prompt()
+
+    m_ctypes.c_void_p.in_dll.assert_has_calls([
+        call(api, stdin),
+        call(api, stderr),
+    ])

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -11,11 +11,11 @@ def platform(request):
 
 
 @patch('aioconsole.apython.ctypes')
-@patch('aioconsole.apython.platform')
-def test_input_with_stderr_prompt_darwin(m_platform, m_ctypes, platform):
-    m_platform.system.return_value = platform
+@patch('aioconsole.apython.sys')
+def test_input_with_stderr_prompt_darwin(m_sys, m_ctypes, platform):
+    m_sys.platform = platform
 
-    if platform == 'Darwin':
+    if platform == 'darwin':
         stdin = '__stdinp'
         stderr = '__stderrp'
     else:

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -4,15 +4,16 @@ import pytest
 
 from aioconsole import apython
 
+
 @pytest.fixture(params=['Darwin', 'Linux'])
 def platform(request):
     return request.param
+
 
 @patch('aioconsole.apython.ctypes')
 @patch('aioconsole.apython.platform')
 def test_input_with_stderr_prompt_darwin(m_platform, m_ctypes, platform):
     m_platform.system.return_value = platform
-
 
     if platform == 'Darwin':
         stdin = '__stdinp'


### PR DESCRIPTION
Mac OS X does not provide 'stdin', 'stdout', or 'stderr' symbols in its export libraries. It turns out that the symbols are named: '__stdinp', '__stdoutp', and '__stderrp'.