### PR TITLE
Support ainput from within an asynchronous console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache
 
 # Translations
 *.mo

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # Installer logs
 pip-log.txt
@@ -55,5 +56,3 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
-
-

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,10 @@ aioconsole
    :target: https://travis-ci.org/vxgmichel/aioconsole
    :alt:
 
+.. image:: https://coveralls.io/repos/github/vxgmichel/aioconsole/badge.svg?branch=master
+   :target: https://coveralls.io/github/vxgmichel/aioconsole?branch=master
+   :alt:
+
 .. image:: https://img.shields.io/pypi/v/aioconsole.svg
    :target: https://pypi.python.org/pypi/aioconsole
    :alt:

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -74,17 +74,19 @@ def parse_args(args=None):
 def run_apython(args=None):
     namespace = parse_args(args)
 
-    try:
-        import readline
-        import rlcompleter
-    except ImportError:
-        readline, rlcompleter = None, None
+    if namespace.readline and not namespace.serve and sys.platform != 'win32':
 
-    if readline and namespace.readline and not namespace.serve:
-        if rlcompleter:
-            readline.parse_and_bind("tab: complete")
-        code = run_apython_in_subprocess(args, namespace.prompt_control)
-        sys.exit(code)
+        try:
+            import readline
+            import rlcompleter
+        except ImportError:
+            readline, rlcompleter = None, None
+
+        if readline:
+            if rlcompleter:
+                readline.parse_and_bind("tab: complete")
+            code = run_apython_in_subprocess(args, namespace.prompt_control)
+            sys.exit(code)
 
     try:
         sys._argv = sys.argv
@@ -120,6 +122,8 @@ def run_apython(args=None):
     finally:
         sys.argv = sys._argv
         sys.path = sys._path
+
+    sys.exit()
 
 
 def run_apython_in_subprocess(args, prompt_control):

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -9,6 +9,7 @@ import argparse
 from . import events
 from . import server
 from . import rlwrap
+from . import compat
 
 DESCRIPTION = """\
 Run the given python file or module with a modified asyncio policy replacing
@@ -74,7 +75,8 @@ def parse_args(args=None):
 def run_apython(args=None):
     namespace = parse_args(args)
 
-    if namespace.readline and not namespace.serve and sys.platform != 'win32':
+    if namespace.readline and not namespace.serve and \
+       compat.platform != 'win32':
 
         try:
             import readline

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -129,25 +129,13 @@ def run_apython(args=None):
 
 
 def run_apython_in_subprocess(args, prompt_control):
-    # Get arguments
-    if args is None:
-        args = sys.argv[1:]
-    if prompt_control is None:
-        prompt_control = rlwrap.ZERO_WIDTH_SPACE
-
-    # Check prompt control
-    assert len(prompt_control) == 1
-
     # Create subprocess
     proc_args = [sys.executable,
                  '-m', 'aioconsole',
-                 '--no-readline',
-                 '--prompt-control', prompt_control]
+                 '--no-readline']
+    if prompt_control:
+        proc_args += ['--prompt-control', prompt_control]
     return rlwrap.rlwrap_process(
         proc_args + args,
         use_stderr=True,
         prompt_control=prompt_control)
-
-
-if __name__ == '__main__':
-    run_apython()

--- a/aioconsole/code.py
+++ b/aioconsole/code.py
@@ -248,7 +248,12 @@ class AsynchronousConsole(code.InteractiveConsole):
 
 
 @asyncio.coroutine
-def interact(banner=None, streams=None, locals=None, stop=True,
+def interact(banner=None, streams=None, locals=None,
+             prompt_control=None, stop=True,
              handle_sigint=True, *, loop=None):
-    console = AsynchronousConsole(streams, locals, loop=loop)
+    console = AsynchronousConsole(
+        streams,
+        locals=locals,
+        prompt_control=prompt_control,
+        loop=loop)
     yield from console.interact(banner, stop, handle_sigint)

--- a/aioconsole/code.py
+++ b/aioconsole/code.py
@@ -65,8 +65,8 @@ class AsynchronousConsole(code.InteractiveConsole):
         self.print(pydoc.render_doc(obj))
 
     @functools.wraps(stream.ainput)
-    async def ainput(self, prompt='', *, streams=None, use_stderr=False,
-                     loop=None):
+    @asyncio.coroutine
+    def ainput(self, prompt='', *, streams=None, use_stderr=False, loop=None):
         # Get the console streams by default
         if streams is None and use_stderr is False:
             streams = self.reader, self.writer
@@ -74,8 +74,8 @@ class AsynchronousConsole(code.InteractiveConsole):
         if self.prompt_control and self.prompt_control not in prompt:
             prompt = self.prompt_control + prompt + self.prompt_control
         # Run ainput
-        return await stream.ainput(
-            prompt, streams=streams, use_stderr=use_stderr, loop=loop)
+        return (yield from stream.ainput(
+            prompt, streams=streams, use_stderr=use_stderr, loop=loop))
 
     def get_default_banner(self):
         cprt = ('Type "help", "copyright", "credits" '

--- a/aioconsole/command.py
+++ b/aioconsole/command.py
@@ -11,8 +11,10 @@ from . import code
 
 class AsynchronousCli(code.AsynchronousConsole):
 
-    def __init__(self, commands, streams=None, *, prog=None, loop=None):
-        super().__init__(streams=streams, loop=loop)
+    def __init__(self, commands, streams=None, *, prog=None,
+                 prompt_control=None, loop=None):
+        super().__init__(
+            streams=streams, prompt_control=prompt_control, loop=loop)
         self.prog = prog
         self.commands = dict(commands)
         self.commands['help'] = (

--- a/aioconsole/compat.py
+++ b/aioconsole/compat.py
@@ -3,3 +3,4 @@
 import sys
 
 PY35 = sys.version_info >= (3, 5)
+platform = sys.platform

--- a/aioconsole/compat.py
+++ b/aioconsole/compat.py
@@ -2,5 +2,4 @@
 
 import sys
 
-PY34 = sys.version_info >= (3, 4)
 PY35 = sys.version_info >= (3, 5)

--- a/aioconsole/events.py
+++ b/aioconsole/events.py
@@ -45,14 +45,13 @@ class InteractiveEventLoop(asyncio.SelectorEventLoop):
             asyncio.Future.cancel(self.console_task)
         super().close()
 
-    if compat.PY34:
-        def __del__(self):
-            if self.console_task and self.console_task.done():
-                self.console_task.exception()
-            try:
-                super().__del__()
-            except AttributeError:
-                pass
+    def __del__(self):
+        if self.console_task and self.console_task.done():
+            self.console_task.exception()
+        try:
+            super().__del__()
+        except AttributeError:
+            pass
 
 
 class InteractiveEventLoopPolicy(asyncio.DefaultEventLoopPolicy):

--- a/aioconsole/events.py
+++ b/aioconsole/events.py
@@ -13,24 +13,30 @@ class InteractiveEventLoop(asyncio.SelectorEventLoop):
 
     console_class = code.AsynchronousConsole
 
-    def __init__(self, *, selector=None, locals=None, banner=None, serve=None):
+    def __init__(self, *, selector=None, locals=None, banner=None, serve=None,
+                 prompt_control=None):
         self.console = None
         self.console_task = None
         self.console_server = None
         super().__init__(selector=selector)
         # Factory
         self.factory = lambda streams: self.console_class(
-            streams, locals=locals, loop=self)
+            streams, locals=locals, prompt_control=prompt_control, loop=self)
         # Local console
         if serve is None:
             self.console = self.factory(None)
-            coro = self.console.interact(banner, stop=True, handle_sigint=True)
+            coro = self.console.interact(
+                banner, stop=True, handle_sigint=True)
             self.console_task = asyncio.ensure_future(coro, loop=self)
         # Serving console
         else:
             host, port = serve
             coro = server.start_interactive_server(
-                self.factory, host=host, port=port, banner=banner, loop=self)
+                self.factory,
+                host=host,
+                port=port,
+                banner=banner,
+                loop=self)
             self.console_server = self.run_until_complete(coro)
             server.print_server(self.console_server)
 
@@ -52,23 +58,35 @@ class InteractiveEventLoop(asyncio.SelectorEventLoop):
 class InteractiveEventLoopPolicy(asyncio.DefaultEventLoopPolicy):
     """Policy to use the interactive event loop by default."""
 
-    def __init__(self, *, locals=None, banner=None, serve=None):
+    def __init__(self, *, locals=None, banner=None, serve=None,
+                 prompt_control=None):
         self._loop_factory = functools.partial(
-            InteractiveEventLoop, locals=locals, banner=banner, serve=serve)
+            InteractiveEventLoop,
+            locals=locals,
+            banner=banner,
+            serve=serve,
+            prompt_control=prompt_control)
         super().__init__()
 
 
-def set_interactive_policy(*, locals=None, banner=None, serve=None):
+def set_interactive_policy(*, locals=None, banner=None, serve=None,
+                           prompt_control=None):
     """Use an interactive event loop by default."""
     policy = InteractiveEventLoopPolicy(
-        locals=locals, banner=banner, serve=serve)
+        locals=locals,
+        banner=banner,
+        serve=serve,
+        prompt_control=prompt_control)
     asyncio.set_event_loop_policy(policy)
 
 
-def run_console(*, locals=None, banner=None, serve=None):
+def run_console(*, locals=None, banner=None, serve=None, prompt_control=None):
     """Run the interactive event loop."""
     loop = InteractiveEventLoop(
-        locals=locals, banner=banner, serve=serve)
+        locals=locals,
+        banner=banner,
+        serve=serve,
+        prompt_control=prompt_control)
     asyncio.set_event_loop(loop)
     try:
         loop.run_forever()

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -23,20 +23,13 @@ def rlwrap_process(args=None, use_stderr=False,
         bufsize=0,
         universal_newlines=True,
         stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+        **{'stderr' if use_stderr else 'stdout': subprocess.PIPE})
     # Readline wrapping
     return _rlwrap(process, use_stderr, prompt_control)
 
 
 def _rlwrap(process, use_stderr=False,
             prompt_control=ZERO_WIDTH_SPACE):
-    # Bind unused stream
-    source = process.stdout if use_stderr else process.stderr
-    dest = sys.stdout if use_stderr else sys.stderr
-    pipe_thread = threading.Thread(target=bind, args=(source, dest))
-    pipe_thread.start()
-
     # Get source and destination
     source = process.stderr if use_stderr else process.stdout
     dest = sys.stderr if use_stderr else sys.stdout
@@ -59,15 +52,7 @@ def _rlwrap(process, use_stderr=False,
 
     # Clean up
     dest.write(source.read())
-    pipe_thread.join()
     return process.returncode
-
-
-def bind(src, dest, value=True, buffersize=1):
-    while value:
-        value = src.read(buffersize)
-        dest.write(value)
-        dest.flush()
 
 
 def wait_for_prompt(src, dest, prompt_control, buffersize=1):

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -61,9 +61,9 @@ def _rlwrap(process, use_stderr=False,
     return process.returncode
 
 
-def bind(src, dest, value=True):
+def bind(src, dest, value=True, buffersize=4096):
     while value:
-        value = src.read(1)
+        value = src.read(buffersize)
         dest.write(value)
         dest.flush()
 

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -4,7 +4,6 @@ import sys
 import ctypes
 import signal
 import builtins
-import threading
 import subprocess
 
 from . import compat
@@ -12,11 +11,11 @@ from . import compat
 ZERO_WIDTH_SPACE = '\u200b'
 
 
-def rlwrap_process(args=None, use_stderr=False,
-                   prompt_control=ZERO_WIDTH_SPACE):
-    # Get args
-    if args is None:
-        args = sys.argv[1:]
+def rlwrap_process(args, use_stderr=False, prompt_control=None):
+    # Default prompt control
+    if prompt_control is None:
+        prompt_control = ZERO_WIDTH_SPACE
+    assert len(prompt_control) == 1
     # Start process
     process = subprocess.Popen(
         args,

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -104,7 +104,7 @@ def input(prompt='', use_stderr=False):
         ferr = ctypes.c_void_p.in_dll(api, stderr)
     # Cygwin fallback
     except ValueError:
-        return input(prompt)
+        return builtins.input(prompt)
     # Call readline
     call_readline = api.PyOS_Readline
     call_readline.restype = ctypes.c_char_p

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -7,6 +7,8 @@ import builtins
 import threading
 import subprocess
 
+from . import compat
+
 ZERO_WIDTH_SPACE = '\u200b'
 
 
@@ -106,7 +108,7 @@ def input(prompt='', use_stderr=False):
         return builtins.input(prompt)
     api = ctypes.pythonapi
     # Cross-platform compatibility
-    if sys.platform == 'darwin':
+    if compat.platform == 'darwin':
         stdin = '__stdinp'
         stderr = '__stderrp'
     else:

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -4,6 +4,7 @@ import sys
 import ctypes
 import signal
 import builtins
+import threading
 import subprocess
 
 ZERO_WIDTH_SPACE = '\u200b'
@@ -14,22 +15,27 @@ def rlwrap_process(args=None, use_stderr=False,
     # Get args
     if args is None:
         args = sys.argv[1:]
-    # Piping
-    kwargs = {'stderr' if use_stderr else 'stdout': subprocess.PIPE}
     # Start process
     process = subprocess.Popen(
         args,
         bufsize=0,
         universal_newlines=True,
         stdin=subprocess.PIPE,
-        **kwargs)
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
     # Readline wrapping
     return _rlwrap(process, use_stderr, prompt_control)
 
 
 def _rlwrap(process, use_stderr=False,
             prompt_control=ZERO_WIDTH_SPACE):
-    # Get destination
+    # Bind unused stream
+    source = process.stdout if use_stderr else process.stderr
+    dest = sys.stdout if use_stderr else sys.stderr
+    pipe_thread = threading.Thread(target=bind, args=(source, dest))
+    pipe_thread.start()
+
+    # Get source and destination
     source = process.stderr if use_stderr else process.stdout
     dest = sys.stderr if use_stderr else sys.stdout
 
@@ -51,7 +57,15 @@ def _rlwrap(process, use_stderr=False,
 
     # Clean up
     dest.write(source.read())
+    pipe_thread.join()
     return process.returncode
+
+
+def bind(src, dest, value=True):
+    while value:
+        value = src.read(1)
+        dest.write(value)
+        dest.flush()
 
 
 def wait_for_prompt(src, dest, prompt_control, current='\n'):

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -1,0 +1,115 @@
+"""Provide a readline wrapper to control a subprocess."""
+
+import sys
+import ctypes
+import signal
+import builtins
+import subprocess
+
+ZERO_WIDTH_SPACE = '\u200b'
+
+
+def rlwrap_process(args=None, use_stderr=False,
+                   prompt_control=ZERO_WIDTH_SPACE):
+    # Get args
+    if args is None:
+        args = sys.argv[1:]
+    # Piping
+    kwargs = {'stderr' if use_stderr else 'stdout': subprocess.PIPE}
+    # Start process
+    process = subprocess.Popen(
+        args,
+        bufsize=0,
+        universal_newlines=True,
+        stdin=subprocess.PIPE,
+        **kwargs)
+    # Readline wrapping
+    return _rlwrap(process, use_stderr, prompt_control)
+
+
+def _rlwrap(process, use_stderr=False,
+            prompt_control=ZERO_WIDTH_SPACE):
+    # Get destination
+    source = process.stderr if use_stderr else process.stdout
+    dest = sys.stderr if use_stderr else sys.stdout
+
+    # Check prompt control
+    assert len(prompt_control) == 1
+
+    # Loop over prompts
+    while process.poll() is None:
+        try:
+            prompt = wait_for_prompt(
+                source, dest, prompt_control)
+            raw = input(prompt, use_stderr=use_stderr) + '\n'
+        except KeyboardInterrupt:
+            process.send_signal(signal.SIGINT)
+        except EOFError:
+            process.stdin.close()
+        else:
+            process.stdin.write(raw)
+
+    # Clean up
+    dest.write(source.read())
+    return process.returncode
+
+
+def wait_for_prompt(src, dest, prompt_control, current='\n'):
+
+    # Read exactly one byte
+    def read_one():
+        value = src.read(1)
+        if value:
+            return value
+        raise EOFError
+
+    while True:
+        # Prompt detection
+        if current.endswith('\n'):
+            current = read_one()
+            if current.startswith(prompt_control):
+                current += read_one()
+                while current[-1] not in (prompt_control, '\n'):
+                    current += read_one()
+                if current.endswith(prompt_control):
+                    return current[1:-1]
+        # Regular read
+        else:
+            current = read_one()
+        # Write and flush
+        dest.write(current)
+        dest.flush()
+
+
+def input(prompt='', use_stderr=False):
+    # Use readline if possible
+    try:
+        import readline
+    except ImportError:
+        return builtins.input(prompt)
+    # Use stdout
+    if not use_stderr:
+        return builtins.input(prompt)
+    api = ctypes.pythonapi
+    # Cross-platform compatibility
+    if sys.platform == 'darwin':
+        stdin = '__stdinp'
+        stderr = '__stderrp'
+    else:
+        stdin = 'stdin'
+        stderr = 'stderr'
+    # Get standard streams
+    try:
+        fin = ctypes.c_void_p.in_dll(api, stdin)
+        ferr = ctypes.c_void_p.in_dll(api, stderr)
+    # Cygwin fallback
+    except ValueError:
+        return input(prompt)
+    # Call readline
+    call_readline = api.PyOS_Readline
+    call_readline.restype = ctypes.c_char_p
+    result = call_readline(fin, ferr, prompt.encode())
+    # Decode result
+    if len(result) == 0:
+        raise EOFError
+    return result.decode().rstrip('\n')

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -30,7 +30,7 @@ def start_console_server(host='localhost', port=8000,
                          prompt_control=None, *, loop=None):
     factory = lambda streams: code.AsynchronousConsole(
         streams, locals, filename, prompt_control=prompt_control)
-    server = yield from asyncio.start_console_server(
+    server = yield from start_interactive_server(
         factory,
         host=host,
         port=port,

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -27,13 +27,16 @@ def start_interactive_server(factory=code.AsynchronousConsole,
 @asyncio.coroutine
 def start_console_server(host='localhost', port=8000,
                          locals=None, filename="<console>", banner=None,
-                         *, loop=None):
+                         prompt_control=None, *, loop=None):
     factory = lambda streams: code.AsynchronousConsole(
-        streams, locals, filename)
+        streams, locals, filename, prompt_control=prompt_control)
     server = yield from asyncio.start_console_server(
-        factory, host, port, banner, loop=loop)
+        factory,
+        host=host,
+        port=port,
+        banner=banner,
+        loop=loop)
     return server
-
 
 
 def print_server(server, name='console'):

--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -26,14 +26,12 @@ class StandardStreamReaderProtocol(asyncio.StreamReaderProtocol):
 
 class StandardStreamReader(asyncio.StreamReader):
 
-    if compat.PY34:
-        __del__ = protect_standard_streams
+    __del__ = protect_standard_streams
 
 
 class StandardStreamWriter(asyncio.StreamWriter):
 
-    if compat.PY34:
-        __del__ = protect_standard_streams
+    __del__ = protect_standard_streams
 
     def write(self, data):
         if isinstance(data, str):

--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -154,8 +154,6 @@ def create_standard_streams(stdin, stdout, stderr, *, loop=None):
 
 @asyncio.coroutine
 def get_standard_streams(*, cache={}, use_stderr=False, loop=None):
-    if loop is None:
-        loop = asyncio.get_event_loop()
     key = sys.stdin, sys.stdout, sys.stderr
     if cache.get(key) is None:
         connection = create_standard_streams(*key, loop=loop)
@@ -167,8 +165,6 @@ def get_standard_streams(*, cache={}, use_stderr=False, loop=None):
 @asyncio.coroutine
 def ainput(prompt='', *, streams=None, use_stderr=False, loop=None):
     """Asynchronous equivalent to *input*."""
-    if loop is None:
-        loop = asyncio.get_event_loop()
     # Get standard streams
     if streams is None:
         streams = yield from get_standard_streams(
@@ -180,11 +176,7 @@ def ainput(prompt='', *, streams=None, use_stderr=False, loop=None):
     # Get data
     data = yield from reader.readline()
     # Decode data
-    try:
-        data = data.decode()
-    except UnicodeDecodeError:
-        if b'\xff\xf4\xff\xfd\x06' in data:
-            raise SystemExit
+    data = data.decode()
     # Return or raise EOF
     if not data.endswith('\n'):
         raise EOFError

--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -126,7 +126,7 @@ def open_stantard_pipe_connection(pipe_in, pipe_out, pipe_err, *, loop=None):
 @asyncio.coroutine
 def create_standard_streams(stdin, stdout, stderr, *, loop=None):
     try:
-        if sys.platform == 'win32':
+        if compat.platform == 'win32':
             raise OSError
         stdin.fileno(), stdout.fileno(), stderr.fileno()
     except OSError:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,10 @@ aioconsole
    :target: https://travis-ci.org/vxgmichel/aioconsole
    :alt:
 
+.. image:: https://coveralls.io/repos/github/vxgmichel/aioconsole/badge.svg?branch=master
+   :target: https://coveralls.io/github/vxgmichel/aioconsole?branch=master
+   :alt:
+
 .. image:: https://img.shields.io/pypi/v/aioconsole.svg
    :target: https://pypi.python.org/pypi/aioconsole
    :alt:

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -137,3 +137,19 @@ def test_apython_server(capfd, event_loop, monkeypatch):
     out, err = capfd.readouterr()
     assert out.startswith('The console is being served on')
     assert err == ''
+
+
+def test_apython_non_existing_file(capfd):
+    with pytest.raises(SystemExit):
+        apython.run_apython(['idontexist.py'])
+    out, err = capfd.readouterr()
+    assert out == ''
+    assert "No such file or directory: 'idontexist.py'" in err
+
+
+def test_apython_non_existing_module(capfd):
+    with pytest.raises(SystemExit):
+        apython.run_apython(['-m', 'idontexist'])
+    out, err = capfd.readouterr()
+    assert out == ''
+    assert "No module named idontexist" in err

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, call
 
 import pytest
 
-from aioconsole import apython
+from aioconsole import apython, rlwrap
 
 
 @pytest.fixture(params=['darwin', 'linux'])
@@ -12,8 +12,8 @@ def platform(request):
     return request.param
 
 
-@patch('aioconsole.apython.ctypes')
-@patch('aioconsole.apython.sys')
+@patch('aioconsole.rlwrap.ctypes')
+@patch('aioconsole.rlwrap.sys')
 def test_input_with_stderr_prompt_darwin(m_sys, m_ctypes, platform):
     m_sys.platform = platform
 
@@ -29,7 +29,7 @@ def test_input_with_stderr_prompt_darwin(m_sys, m_ctypes, platform):
     result = call_readline.return_value
     result.__len__.return_value = 1
 
-    apython.input_with_stderr_prompt()
+    rlwrap.input(use_stderr=True)
 
     m_ctypes.c_void_p.in_dll.assert_has_calls([
         call(api, stdin),

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -60,6 +60,9 @@ def mock_readline(platform):
 @pytest.fixture(params=['readline', 'no-readline'])
 def use_readline(request, mock_readline, platform):
     if request.param == 'readline':
+        # Readline tests hang on windows for some reason
+        if sys.platform == 'win32':
+            pytest.xfail()
         return [] if platform == 'win32' else ['--prompt-control=▲']
     return ['--no-readline']
 

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -74,59 +74,59 @@ def test_input_with_stderr_prompt(mock_readline):
         assert rlwrap.input(use_stderr=True) == 'test'
 
 
-def test_basic_apython_usage(capsys, use_readline):
+def test_basic_apython_usage(capfd, use_readline):
     with patch('sys.stdin', new=io.StringIO('1+1\n')):
         with pytest.raises(SystemExit):
             apython.run_apython(['--banner=test'] + use_readline)
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert out == ''
     assert err == 'test\n>>> 2\n>>> \n'
 
 
-def test_apython_with_prompt_control(capsys):
+def test_apython_with_prompt_control(capfd):
     with patch('sys.stdin', new=io.StringIO('1+1\n')):
         with pytest.raises(SystemExit):
             apython.run_apython(
                 ['--banner=test', '--prompt-control=▲', '--no-readline'])
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert out == ''
     assert err == 'test\n▲>>> ▲2\n▲>>> ▲\n'
 
 
-def test_apython_with_prompt_control_and_ainput(capsys):
+def test_apython_with_prompt_control_and_ainput(capfd):
     input_string = "{} ainput()\nhello\n".format(
         'await' if compat.PY35 else 'yield from')
     with patch('sys.stdin', new=io.StringIO(input_string)):
         with pytest.raises(SystemExit):
             apython.run_apython(
                 ['--no-readline', '--banner=test', '--prompt-control=▲'])
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert out == ''
     assert err == "test\n▲>>> ▲▲▲'hello'\n▲>>> ▲\n"
 
 
-def test_apython_with_ainput(capsys, use_readline):
+def test_apython_with_ainput(capfd, use_readline):
     input_string = "{} ainput()\nhello\n".format(
         'await' if compat.PY35 else 'yield from')
     with patch('sys.stdin', new=io.StringIO(input_string)):
         with pytest.raises(SystemExit):
             apython.run_apython(['--banner=test'] + use_readline)
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert out == ''
     assert err == "test\n>>> 'hello'\n>>> \n"
 
 
-def test_apython_with_stdout_logs(capsys, use_readline):
+def test_apython_with_stdout_logs(capfd, use_readline):
     with patch('sys.stdin', new=io.StringIO(
-            'import sys; sys.stdout.write("logging")\n')):
+            'import sys; sys.stdout.write("logging") or 7\n')):
         with pytest.raises(SystemExit):
             apython.run_apython(['--banner=test'] + use_readline)
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert out == 'logging'
     assert err == 'test\n>>> 7\n>>> \n'
 
 
-def test_apython_server(capsys, event_loop, monkeypatch):
+def test_apython_server(capfd, event_loop, monkeypatch):
     def run_forever(self, orig=InteractiveEventLoop.run_forever):
         if self.console_server is not None:
             self.call_later(0, self.stop)
@@ -134,6 +134,6 @@ def test_apython_server(capsys, event_loop, monkeypatch):
     with patch('aioconsole.InteractiveEventLoop.run_forever', run_forever):
         with pytest.raises(SystemExit):
             apython.run_apython(['--serve=:0'])
-    out, err = capsys.readouterr()
+    out, err = capfd.readouterr()
     assert out.startswith('The console is being served on')
     assert err == ''

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -43,3 +43,21 @@ def test_basic_apython_usage(capsys):
     out, err = capsys.readouterr()
     assert out == ''
     assert err == 'test\n>>> 2\n>>> \n'
+
+
+def test_apython_with_prompt_control(capsys):
+    with patch('sys.stdin', new=io.StringIO('1+1\n')):
+        apython.run_apython(
+            ['--no-readline', '--banner=test', '--prompt-control=▲'])
+    out, err = capsys.readouterr()
+    assert out == ''
+    assert err == 'test\n▲>>> ▲2\n▲>>> ▲\n'
+
+
+def test_apython_with_ainput(capsys):
+    with patch('sys.stdin', new=io.StringIO('await ainput()\nhello\n')):
+        apython.run_apython(
+            ['--no-readline', '--banner=test', '--prompt-control=▲'])
+    out, err = capsys.readouterr()
+    assert out == ''
+    assert err == 'test\n▲>>> ▲▲▲hello\n▲>>> ▲\n'

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -25,7 +25,7 @@ def mock_module(name):
 
 @pytest.fixture(params=['linux', 'darwin', 'win32'])
 def platform(request):
-    with patch('sys.platform', new=request.param):
+    with patch('aioconsole.compat.platform', new=request.param):
         yield request.param
 
 

--- a/tests/test_apython.py
+++ b/tests/test_apython.py
@@ -100,7 +100,7 @@ def test_apython_with_prompt_control_and_ainput(capsys):
                 ['--no-readline', '--banner=test', '--prompt-control=▲'])
     out, err = capsys.readouterr()
     assert out == ''
-    assert err == 'test\n▲>>> ▲▲▲hello\n▲>>> ▲\n'
+    assert err == "test\n▲>>> ▲▲▲'hello'\n▲>>> ▲\n"
 
 
 def test_apython_with_ainput(capsys, use_readline):
@@ -111,7 +111,7 @@ def test_apython_with_ainput(capsys, use_readline):
             apython.run_apython(['--banner=test'] + use_readline)
     out, err = capsys.readouterr()
     assert out == ''
-    assert err == 'test\n>>> hello\n>>> \n'
+    assert err == "test\n>>> 'hello'\n>>> \n"
 
 
 def test_apython_with_stdout_logs(capsys, use_readline):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -97,10 +97,10 @@ def make_cli(streams=None):
     list(testdata.values()),
     ids=list(testdata.keys()))
 @pytest.mark.asyncio
-def test_async_cli(event_loop, input_string, expected):
-    sys.ps1 = "[Hello!] "
-    sys.stdin = io.StringIO(input_string)
-    sys.stderr = io.StringIO()
+def test_async_cli(event_loop, monkeypatch, input_string, expected):
+    monkeypatch.setattr('sys.ps1', "[Hello!] ", raising=False)
+    monkeypatch.setattr('sys.stdin', io.StringIO(input_string))
+    monkeypatch.setattr('sys.stderr', io.StringIO())
     yield from make_cli().interact(stop=False)
     print(sys.stderr.getvalue())
     assert sys.stderr.getvalue() == expected

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -1,33 +1,108 @@
 
 import io
+import os
 import sys
+import signal
+import asyncio
+from contextlib import contextmanager
 
 import pytest
-from aioconsole import interact
 from aioconsole import compat
+from aioconsole import interact
+from aioconsole.stream import NonFileStreamReader, NonFileStreamWriter
+
+
+@contextmanager
+def stdcontrol(event_loop, monkeypatch):
+    with monkeypatch.context() as m:
+        # PS1
+        m.setattr('sys.ps1', "[Hello!]")
+        # Stdin control
+        stdin_read, stdin_write = os.pipe()
+        m.setattr('sys.stdin', open(stdin_read))
+        writer = NonFileStreamWriter(open(stdin_write, 'w'), loop=event_loop)
+        # Stdout control
+        m.setattr(sys, 'stdout', io.StringIO())
+        # Stderr control
+        stderr_read, stderr_write = os.pipe()
+        m.setattr('sys.stderr', open(stderr_write, 'w'))
+        reader = NonFileStreamReader(open(stderr_read), loop=event_loop)
+        # Yield
+        yield reader, writer
+        # Check
+        assert sys.stdout.getvalue() == ''
+
+
+@asyncio.coroutine
+def assert_stream(stream, expected):
+    for line in expected.splitlines():
+        assert line == (yield from stream.readline()).decode().strip('\n')
 
 
 @pytest.mark.asyncio
-def test_interact_simple(event_loop):
-    sys.ps1 = "[Hello!]"
-    sys.stdin = io.StringIO('1+1\n')
-    sys.stderr = io.StringIO()
-    banner = "A BANNER"
-    expected = '\n'.join((banner, sys.ps1 + '2', sys.ps1)) + '\n'
-    yield from interact(banner=banner, stop=False)
-    assert sys.stderr.getvalue() == expected
+def test_interact_simple(event_loop, monkeypatch):
+    with stdcontrol(event_loop, monkeypatch) as (reader, writer):
+        banner = "A BANNER"
+        writer.write('1+1\n')
+        writer.stream.close()
+        yield from interact(banner=banner, stop=False)
+        yield from assert_stream(reader, banner)
+        yield from assert_stream(reader, sys.ps1 + '2')
+        yield from assert_stream(reader, sys.ps1)
 
 
 @pytest.mark.asyncio
-def test_interact_traceback(event_loop):
-    sys.ps1 = "[Hello!] "
-    sys.stdin = io.StringIO('1/0\n')
-    sys.stderr = io.StringIO()
-    banner = "A BANNER"
-    yield from interact(banner=banner, stop=False)
-    lines = sys.stderr.getvalue().splitlines()
-    assert lines[0] == banner
-    assert lines[1] == sys.ps1 + "Traceback (most recent call last):"
-    index = 5 if compat.PY35 else 7
-    assert lines[index] == "ZeroDivisionError: division by zero"
-    assert lines[index+1] == sys.ps1
+def test_interact_traceback(event_loop, monkeypatch):
+    with stdcontrol(event_loop, monkeypatch) as (reader, writer):
+        banner = "A BANNER"
+        writer.write('1/0\n')
+        writer.stream.close()
+        yield from interact(banner=banner, stop=False)
+        # Check stderr
+        yield from assert_stream(reader, banner)
+        yield from assert_stream(
+            reader, sys.ps1 + 'Traceback (most recent call last):')
+        # Skip 3 (or 5) lines
+        for _ in range(3 if compat.PY35 else 5):
+            yield from reader.readline()
+        # Check stderr
+        yield from assert_stream(reader, "ZeroDivisionError: division by zero")
+        yield from assert_stream(reader, sys.ps1)
+
+
+@pytest.mark.asyncio
+def test_interact_syntax_error(event_loop, monkeypatch):
+    with stdcontrol(event_loop, monkeypatch) as (reader, writer):
+        writer.write('a b\n')
+        writer.stream.close()
+        banner = "A BANNER"
+        yield from interact(banner=banner, stop=False)
+        yield from assert_stream(reader, banner)
+        # Skip line
+        yield from reader.readline()
+        yield from assert_stream(reader, '    a b')
+        yield from assert_stream(reader, '      ^')
+        yield from assert_stream(reader, 'SyntaxError: invalid syntax')
+        yield from assert_stream(reader, sys.ps1)
+
+
+@pytest.mark.asyncio
+def test_interact_keyboard_interrupt(event_loop, monkeypatch):
+    with stdcontrol(event_loop, monkeypatch) as (reader, writer):
+        # Start interaction
+        banner = "A BANNER"
+        task = asyncio.ensure_future(interact(banner=banner, stop=False))
+        # Wait for banner
+        yield from assert_stream(reader, banner)
+        # Send SIGINT
+        os.kill(os.getpid(), signal.SIGINT)
+        # Wait for ps1
+        yield from assert_stream(reader, sys.ps1)
+        yield from assert_stream(reader, "KeyboardInterrupt")
+        # Close stdin
+        writer.stream.close()
+        # Wait for interact to finish
+        yield from assert_stream(reader, sys.ps1)
+        yield from task
+        # Test
+        assert sys.stdout.getvalue() == ''

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -15,23 +15,22 @@ from aioconsole.stream import NonFileStreamReader, NonFileStreamWriter
 
 @contextmanager
 def stdcontrol(event_loop, monkeypatch):
-    with monkeypatch.context() as m:
-        # PS1
-        m.setattr('sys.ps1', "[Hello!]")
-        # Stdin control
-        stdin_read, stdin_write = os.pipe()
-        m.setattr('sys.stdin', open(stdin_read))
-        writer = NonFileStreamWriter(open(stdin_write, 'w'), loop=event_loop)
-        # Stdout control
-        m.setattr(sys, 'stdout', io.StringIO())
-        # Stderr control
-        stderr_read, stderr_write = os.pipe()
-        m.setattr('sys.stderr', open(stderr_write, 'w'))
-        reader = NonFileStreamReader(open(stderr_read), loop=event_loop)
-        # Yield
-        yield reader, writer
-        # Check
-        assert sys.stdout.getvalue() == ''
+    # PS1
+    monkeypatch.setattr('sys.ps1', "[Hello!]")
+    # Stdin control
+    stdin_read, stdin_write = os.pipe()
+    monkeypatch.setattr('sys.stdin', open(stdin_read))
+    writer = NonFileStreamWriter(open(stdin_write, 'w'), loop=event_loop)
+    # Stdout control
+    monkeypatch.setattr(sys, 'stdout', io.StringIO())
+    # Stderr control
+    stderr_read, stderr_write = os.pipe()
+    monkeypatch.setattr('sys.stderr', open(stderr_write, 'w'))
+    reader = NonFileStreamReader(open(stderr_read), loop=event_loop)
+    # Yield
+    yield reader, writer
+    # Check
+    assert sys.stdout.getvalue() == ''
 
 
 @asyncio.coroutine

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,18 @@
+import asyncio
+
+import pytest
+
+from aioconsole.server import start_console_server
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_server(event_loop):
+    server = yield from start_console_server(port=0, banner='test')
+    address = server.sockets[0].getsockname()
+    reader, writer = yield from asyncio.open_connection(*address)
+    assert (yield from reader.readline()) == b'test\n'
+    writer.write(b'1+1\n')
+    assert (yield from reader.readline()) == b'>>> 2\n'
+    writer.close()
+    assert (yield from reader.readline()) == b'>>> '

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,99 @@
+import os
+import io
+import sys
+import pytest
+import asyncio
+from unittest.mock import Mock
+
+from aioconsole import compat
+from aioconsole.stream import create_standard_streams, ainput
+from aioconsole.stream import is_pipe_transport_compatible
+
+@pytest.mark.skipif(
+    sys.platform == 'win32',
+    reason='Not supported on windows')
+@pytest.mark.asyncio
+def test_create_standard_stream_with_pipe():
+    r, w = os.pipe()
+    stdin = open(r)
+    stdout = open(w, 'w')
+    stderr = open(w, 'w')
+
+    assert is_pipe_transport_compatible(stdin)
+    assert is_pipe_transport_compatible(stdout)
+    assert is_pipe_transport_compatible(stderr)
+
+    reader, writer1, writer2 = yield from create_standard_streams(
+        stdin, stdout, stderr)
+
+
+    writer1.write('a\n')
+    yield from writer1.drain()
+    data = yield from reader.readline()
+    assert data == b'a\n'
+
+    writer2.write('b\n')
+    yield from writer2.drain()
+    data = yield from reader.readline()
+    assert data == b'b\n'
+
+    reader._transport = None
+    stdout.fileno = Mock(return_value=0)
+    get_extra_info = Mock(side_effect=OSError)
+    writer2._transport.get_extra_info = get_extra_info
+    del reader, writer1, writer2
+    stdout.fileno.assert_called_once_with()
+    get_extra_info.assert_called_once_with('pipe')
+
+
+@pytest.mark.asyncio
+def test_create_standard_stream_with_non_pipe():
+    stdin = io.StringIO('a\nb\nc\nd\n')
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    reader, writer1, writer2 = yield from create_standard_streams(
+        stdin, stdout, stderr)
+
+    writer1.write('a\n')
+    yield from writer1.drain()
+    data = yield from reader.readline()
+    assert data == b'a\n'
+    assert stdout.getvalue() == 'a\n'
+
+    writer2.write('b\n')
+    yield from writer2.drain()
+    data = yield from reader.readline()
+    assert data == b'b\n'
+    assert stderr.getvalue() == 'b\n'
+
+    writer2.stream = Mock(spec={})
+    yield from writer2.drain()
+
+    data = yield from reader.read(2)
+    assert data == b'c\n'
+
+    assert reader.at_eof() == False
+
+    if compat.PY35:
+        assert (yield from reader.__aiter__()) == reader
+        assert (yield from reader.__anext__()) == b'd\n'
+        with pytest.raises(StopAsyncIteration):
+            yield from reader.__anext__()
+    else:
+        assert (yield from reader.read()) == b'd\n'
+        assert (yield from reader.read()) == b''
+
+    assert reader.at_eof() == True
+
+
+@pytest.mark.asyncio
+def test_ainput_with_standard_stream(monkeypatch):
+    string = 'a\nb\n'
+    monkeypatch.setattr('sys.stdin', io.StringIO(string))
+    monkeypatch.setattr('sys.stdout', io.StringIO())
+    monkeypatch.setattr('sys.stderr', io.StringIO())
+
+    assert (yield from ainput()) == 'a'
+    assert (yield from ainput('>>> ')) == 'b'
+    assert sys.stdout.getvalue() == '>>> '
+    assert sys.stderr.getvalue() == ''

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -13,6 +13,7 @@ from aioconsole.stream import is_pipe_transport_compatible
     sys.platform == 'win32',
     reason='Not supported on windows')
 @pytest.mark.asyncio
+@asyncio.coroutine
 def test_create_standard_stream_with_pipe():
     r, w = os.pipe()
     stdin = open(r)
@@ -47,6 +48,7 @@ def test_create_standard_stream_with_pipe():
 
 
 @pytest.mark.asyncio
+@asyncio.coroutine
 def test_create_standard_stream_with_non_pipe():
     stdin = io.StringIO('a\nb\nc\nd\n')
     stdout = io.StringIO()


### PR DESCRIPTION
Fix issue #8 by:
- caching `stdin`, `stdout` and `stderr` all together
- exposing a client specific `ainput` function in the console namespace
- refactoring readline support using an arbitrary prompt control character

Also, improve the tests.
