### PR TITLE
Prefer repr over str for execution results

### DIFF
--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -30,7 +30,7 @@ def exec_result(obj, local, stream):
     """Reproduce default exec behavior (print and builtins._)"""
     local['_'] = obj
     if obj is not None:
-        print(obj, file=stream)
+        print(repr(obj), file=stream)
 
 
 def make_tree(statement, filename="<aexec>", symbol="single", local={}):


### PR DESCRIPTION
Currently, the result of each statement (including just naming an object in scope) is printed to the console by its `__str__`, whereas the plain Python console uses `__repr__`.  This PR makes the naive change of calling `repr()` on a result before printing it, though I'm unsure if there's any side-effects of doing so.