### PR TITLE
Fix apython argument parsing when used with module and arguments

### DIFF
--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -53,12 +53,10 @@ def parse_args(args=None):
 
     # Input
 
-    group = parser.add_mutually_exclusive_group()
-
-    group.add_argument(
+    parser.add_argument(
         '-m', dest='module',
         help='run a python module')
-    group.add_argument(
+    parser.add_argument(
         'filename', metavar='FILE', nargs='?',
         help='python file to run')
 
@@ -69,8 +67,15 @@ def parse_args(args=None):
         help='extra arguments')
 
     namespace = parser.parse_args(args)
+
+    # If module is provided, filname is actually the fist arg
+    if namespace.module is not None and namespace.filename is not None:
+        namespace.args.insert(0, namespace.filename)
+
+    # Parse the serve argument
     if namespace.serve is not None:
         namespace.serve = server.parse_server(namespace.serve, parser)
+
     return namespace
 
 

--- a/aioconsole/code.py
+++ b/aioconsole/code.py
@@ -21,6 +21,10 @@ Try: {0} asyncio.sleep(1, result=3)
 ---""".format('await' if compat.PY35 else 'yield from')
 
 
+current_task = (
+    asyncio.current_task if compat.PY37 else asyncio.Task.current_task)
+
+
 class AsynchronousCompiler(codeop.CommandCompiler):
 
     def __init__(self):
@@ -116,7 +120,7 @@ class AsynchronousConsole(code.InteractiveConsole):
             task._wakeup(task._fut_waiter)
 
     def add_sigint_handler(self):
-        task = asyncio.Task.current_task(loop=self.loop)
+        task = current_task(loop=self.loop)
         try:
             self.loop.add_signal_handler(
                 signal.SIGINT, self.handle_sigint, task)

--- a/aioconsole/compat.py
+++ b/aioconsole/compat.py
@@ -3,4 +3,5 @@
 import sys
 
 PY35 = sys.version_info >= (3, 5)
+PY37 = sys.version_info >= (3, 7)
 platform = sys.platform


### PR DESCRIPTION
The following example from the docs stopped working:
```bash
$ apython -m example.echo 8888
usage: apython [-h] [--serve [HOST:] PORT] [--no-readline] [--banner BANNER]
               [--locals LOCALS] [-m MODULE]
               [FILE] ...
apython: error: argument FILE: not allowed with argument -m
```
Also fixes the following warning with python 3.7:
```python
aioconsole/aioconsole/code.py:119: PendingDeprecationWarning: 
Task.current_task() is deprecated, use asyncio.current_task() instead
  task = asyncio.Task.current_task(loop=self.loop)
```
