### PR TITLE
Prevent exception in macOS with large output.

### DIFF
--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -84,8 +84,8 @@ def wait_for_prompt(src, dest, prompt_control, buffersize=1):
             dest.write(arg)
             dest.flush()
 
-    # Prevent BlockingIOError on macOS.
-    fcntl.fcntl(dest.fileno(), fcntl.F_SETFL, 0)
+    if sys.platform == 'darwin':
+        fcntl.fcntl(dest.fileno(), fcntl.F_SETFL, 0)
 
     # Wait for first prompt control
     while True:

--- a/aioconsole/rlwrap.py
+++ b/aioconsole/rlwrap.py
@@ -2,6 +2,7 @@
 
 import sys
 import ctypes
+import fcntl
 import signal
 import builtins
 import subprocess
@@ -82,6 +83,9 @@ def wait_for_prompt(src, dest, prompt_control, buffersize=1):
         if arg:
             dest.write(arg)
             dest.flush()
+
+    # Prevent BlockingIOError on macOS.
+    fcntl.fcntl(dest.fileno(), fcntl.F_SETFL, 0)
 
     # Wait for first prompt control
     while True:


### PR DESCRIPTION
See issue #42.

On macOS 10.14, running a command in apython that produces a
lot of output (such as `help(str)`) causes `BlockingIOError`
to be raised by the call to `dest.flush()` in the `wrap`
function of `rlwrap.py`. Some unknown force is setting
`O_NONBLOCK` on the file descriptor.