### PR TITLE
Add console binding to Unix sockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,13 @@ matrix:
       language: generic
       env: MACPYTHON=3.6.8
       before_install: source .travis-osx-install
+      script: python setup.py test --addopts "--basetemp=$TMPDIR/pytest"
     # OSX - 3.7
     - os: osx
       language: generic
       env: MACPYTHON=3.7.2
       before_install: source .travis-osx-install
+      script: python setup.py test --addopts "--basetemp=$TMPDIR/pytest"
 
 
 install: pip install -U coveralls pytest

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -17,19 +17,23 @@ def handle_connect(reader, writer, factory, banner=None):
 
 @asyncio.coroutine
 def start_interactive_server(factory=code.AsynchronousConsole,
-                             host='localhost', port=8000, path=None,
+                             host=None, port=None, path=None,
                              banner=None, *, loop=None):
     callback = lambda reader, writer: handle_connect(
         reader, writer, factory, banner)
+    if bool(host or port) == bool(path):
+        raise ValueError("Either host/port or socket path should be provided")
     if path:
         server = yield from asyncio.start_unix_server(callback, path, loop=loop)
     else:
+        host = host or "localhost"
+        port = port or 8000
         server = yield from asyncio.start_server(callback, host, port, loop=loop)
     return server
 
 
 @asyncio.coroutine
-def start_console_server(host='localhost', port=8000, path=None,
+def start_console_server(host=None, port=None, path=None,
                          locals=None, filename="<console>", banner=None,
                          prompt_control=None, *, loop=None):
     factory = lambda streams: code.AsynchronousConsole(
@@ -51,7 +55,7 @@ def print_server(server, name='console'):
     print('The {} is being served on {}'.format(name, interface))
 
 
-def run(host='localhost', port=8000, path=None):
+def run(host=None, port=None, path=None):
     loop = asyncio.get_event_loop()
     coro = start_interactive_server(host=host, port=port, path=path)
     loop.server = loop.run_until_complete(coro)

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -51,11 +51,11 @@ def start_console_server(host=None, port=None, path=None,
     return server
 
 
-def print_server(server, name='console'):
+def print_server(server, name='console', file=None):
     interface = server.sockets[0].getsockname()
     if server.sockets[0].family != socket.AF_UNIX:
         interface = '{}:{}'.format(*interface)
-    print('The {} is being served on {}'.format(name, interface))
+    print('The {} is being served on {}'.format(name, interface), file=file)
 
 
 def run(host=None, port=None, path=None):

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -21,13 +21,13 @@ def start_interactive_server(factory=code.AsynchronousConsole,
                              banner=None, *, loop=None):
     callback = lambda reader, writer: handle_connect(
         reader, writer, factory, banner)
-    if bool(host or port) == bool(path):
-        raise ValueError("Either host/port or socket path should be provided")
+    if (port is not None) == (path is not None):
+        raise ValueError("Either a TCP port or a UDS path should be provided")
     if path:
         server = yield from asyncio.start_unix_server(callback, path, loop=loop)
     else:
+        # Override asyncio behavior (i.e serve on all interfaces by default)
         host = host or "localhost"
-        port = port or 8000
         server = yield from asyncio.start_server(callback, host, port, loop=loop)
     return server
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,9 +1,10 @@
+import io
 import asyncio
 
 import pytest
 
 from aioconsole import compat
-from aioconsole.server import start_console_server
+from aioconsole.server import start_console_server, print_server
 
 
 @pytest.mark.asyncio
@@ -12,6 +13,12 @@ def test_server(event_loop):
     server = yield from start_console_server(
         host="127.0.0.1", port=0, banner='test')
     address = server.sockets[0].getsockname()
+
+    stream = io.StringIO()
+    print_server(server, "test console", file=stream)
+    expected = "The test console is being served on 127.0.0.1:{}\n"
+    assert stream.getvalue() == expected.format(address[1])
+
     reader, writer = yield from asyncio.open_connection(*address)
     assert (yield from reader.readline()) == b'test\n'
     writer.write(b'1+1\n')
@@ -23,3 +30,37 @@ def test_server(event_loop):
         yield from writer.wait_closed()
     server.close()
     yield from server.wait_closed()
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_uds_server(event_loop, tmpdir):
+    path = str(tmpdir / "test.uds")
+    server = yield from start_console_server(path=path, banner='test')
+
+    stream = io.StringIO()
+    print_server(server, "test console", file=stream)
+    expected = "The test console is being served on {}\n"
+    assert stream.getvalue() == expected.format(path)
+
+    address = server.sockets[0].getsockname()
+    reader, writer = yield from asyncio.open_unix_connection(address)
+    assert (yield from reader.readline()) == b'test\n'
+    writer.write(b'1+1\n')
+    assert (yield from reader.readline()) == b'>>> 2\n'
+    writer.write_eof()
+    assert (yield from reader.readline()) == b'>>> \n'
+    writer.close()
+    if compat.PY37:
+        yield from writer.wait_closed()
+    server.close()
+    yield from server.wait_closed()
+
+
+@pytest.mark.asyncio
+@asyncio.coroutine
+def test_invalid_server(event_loop):
+    with pytest.raises(ValueError):
+        yield from start_console_server()
+    with pytest.raises(ValueError):
+        yield from start_console_server(path="uds", port=0)


### PR DESCRIPTION
On Unix, this allows an asynchronous console to be bound to a socket file:

```python
await aioconsole.start_interactive_server(path="/tmp/console.sock")
```

The socket can then be connected to e.g. via `socat`:

```
$ socat - UNIX-CONNECT:/tmp/console.sock
```

The benefit here is that access to the console can be locked down to the user account running the program (e.g. with a restrictive umask), rather than being open on a port to any user on the system.