### PR TITLE
Drop support for EOL Python 3.4 and 3.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ dist: xenial
 language: python
 
 python:
-- 3.5
-- pypy3.5
+- pypy3
 - 3.6
 - 3.7
 - 3.8

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ aioconsole_ provides:
 Requirements
 ------------
 
-*  Python >= 3.5
+*  Python >= 3.6
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ aioconsole_ provides:
 Requirements
 ------------
 
-*  python >= 3.4
+*  Python >= 3.5
 
 
 Installation

--- a/aioconsole/apython.py
+++ b/aioconsole/apython.py
@@ -45,8 +45,7 @@ def exec_pythonstartup(locals_dict):
                 locals_dict.pop("__file__", None)
 
         else:
-            message = "Could not open PYTHONSTARTUP - No such file: {}"
-            print(message.format(filename))
+            print(f"Could not open PYTHONSTARTUP - No such file: {filename}")
 
 
 def parse_args(args=None):

--- a/aioconsole/command.py
+++ b/aioconsole/command.py
@@ -34,7 +34,7 @@ class AsynchronousCli(console.AsynchronousConsole):
 
     def get_default_banner(self):
         prog = self.prog or sys.argv[0].split("/")[-1]
-        msg = "Welcome to the CLI interface of {0}!\n".format(prog)
+        msg = f"Welcome to the CLI interface of {prog}!\n"
         msg += "Try:\n"
         msg += " * 'help' to display the help message\n"
         msg += " * 'list' to display the command list."
@@ -68,7 +68,7 @@ Type '<command> -h' to display the help message of <command>."""
 
         # Get the command
         if name not in self.commands:
-            self.write("Command '{0}' does not exist.\n".format(name))
+            self.write(f"Command '{name}' does not exist.\n")
             await self.flush()
             return False
         corofunc, parser = self.commands[name]

--- a/aioconsole/console.py
+++ b/aioconsole/console.py
@@ -45,7 +45,7 @@ class AsynchronousConsole(code.InteractiveConsole):
         filename="<console>",
         prompt_control=None,
         *,
-        loop=None
+        loop=None,
     ):
         super().__init__(locals, filename)
         # Process arguments
@@ -93,8 +93,7 @@ class AsynchronousConsole(code.InteractiveConsole):
         cprt = (
             'Type "help", "copyright", "credits" ' 'or "license" for more information.'
         )
-        msg = "Python %s on %s\n%s\n%s"
-        return msg % (sys.version, sys.platform, cprt, EXTRA_MESSAGE)
+        return f"Python {sys.version} on {sys.platform}\n{cprt}\n{EXTRA_MESSAGE}"
 
     async def runsource(self, source, filename="<ainput>", symbol="single"):
         try:
@@ -181,7 +180,7 @@ class AsynchronousConsole(code.InteractiveConsole):
         # Print banner
         if banner is None:
             banner = self.get_default_banner()
-        self.write("%s\n" % str(banner))
+        self.write(f"{banner}\n")
         # Run loop
         more = 0
         while 1:
@@ -264,7 +263,7 @@ async def interact(
     stop=True,
     handle_sigint=True,
     *,
-    loop=None
+    loop=None,
 ):
     console = AsynchronousConsole(
         streams, locals=locals, prompt_control=prompt_control, loop=loop

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -4,7 +4,7 @@ import ast
 import codeop
 
 CORO_NAME = "__corofn"
-CORO_DEF = "async def {}(): ".format(CORO_NAME)
+CORO_DEF = f"async def {CORO_NAME}(): "
 CORO_CODE = CORO_DEF + "return (None, locals())\n"
 
 

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -21,7 +21,7 @@ async def start_interactive_server(
     path=None,
     banner=None,
     *,
-    loop=None
+    loop=None,
 ):
     if (port is None) == (path is None):
         raise ValueError("Either a TCP port or a UDS path should be provided")
@@ -46,7 +46,7 @@ async def start_console_server(
     banner=None,
     prompt_control=None,
     *,
-    loop=None
+    loop=None,
 ):
     def factory(streams):
         client_locals = dict(locals) if locals is not None else None
@@ -67,7 +67,7 @@ def print_server(server, name="console", file=None):
     interface = server.sockets[0].getsockname()
     if server.sockets[0].family != socket.AF_UNIX:
         interface = "{}:{}".format(*interface)
-    print("The {} is being served on {}".format(name, interface), file=file)
+    print(f"The {name} is being served on {interface}", file=file)
 
 
 def run(host=None, port=None, path=None):
@@ -89,7 +89,7 @@ def parse_server(server, parser=None):
     try:
         port = int(port)
     except (ValueError, TypeError):
-        msg = "{!r} is not a valid server [HOST:]PORT".format(server)
+        msg = f"{server!r} is not a valid server [HOST:]PORT"
         if not parser:
             raise ValueError(msg)
         parser.error(msg)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,26 +2,26 @@
 
 import sphinx_rtd_theme
 
-VERSION = open('../setup.py').read().split("version=\"")[1].split("\"")[0]
+VERSION = open("../setup.py").read().split('version="')[1].split('"')[0]
 
-project = 'aioconsole'
+project = "aioconsole"
 version = VERSION
-author = 'Vincent Michel'
-copyright = u'2020, Vincent Michel'
+author = "Vincent Michel"
+copyright = u"2020, Vincent Michel"
 
-master_doc = 'index'
-highlight_language = 'python'
-extensions = ['sphinx.ext.autodoc']
+master_doc = "index"
+highlight_language = "python"
+extensions = ["sphinx.ext.autodoc"]
 
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_context = {
-    'display_github': True,
-    'github_user': 'vxgmichel',
-    'github_repo': 'aioconsole',
-    'github_version': "master",
-    'conf_py_path': "/docs/",
-    'source_suffix': '.rst',
+    "display_github": True,
+    "github_user": "vxgmichel",
+    "github_repo": "aioconsole",
+    "github_version": "master",
+    "conf_py_path": "/docs/",
+    "source_suffix": ".rst",
 }
 
-suppress_warnings = ['image.nonlocal_uri']
+suppress_warnings = ["image.nonlocal_uri"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ VERSION = open("../setup.py").read().split('version="')[1].split('"')[0]
 project = "aioconsole"
 version = VERSION
 author = "Vincent Michel"
-copyright = u"2020, Vincent Michel"
+copyright = "2020, Vincent Michel"
 
 master_doc = "index"
 highlight_language = "python"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ aioconsole_ provides:
 Requirements
 ------------
 
-*  Python >= 3.5
+*  Python >= 3.6
 
 
 Installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,7 +35,7 @@ aioconsole_ provides:
 Requirements
 ------------
 
-*  python >= 3.4
+*  Python >= 3.5
 
 
 Installation

--- a/example/cli.py
+++ b/example/cli.py
@@ -19,9 +19,9 @@ async def get_history(reader, writer, pattern=None):
     if not history:
         return "No host match the given pattern"
     for host in history:
-        writer.write("Host {}:\n".format(host).encode())
+        writer.write(f"Host {host}:\n".encode())
         for i, message in enumerate(history[host]):
-            writer.write("  {}. {}\n".format(i, message).encode())
+            writer.write(f"  {i}. {message}\n".encode())
 
 
 def make_cli(streams=None):

--- a/example/echo.py
+++ b/example/echo.py
@@ -19,7 +19,7 @@ def run(host="localhost", port=8000):
     coro = asyncio.start_server(handle_echo, host, port, loop=loop)
     loop.server = loop.run_until_complete(coro)
     interface = "{}:{}".format(*loop.server.sockets[0].getsockname())
-    print("The echo service is being served on {}".format(interface))
+    print(f"The echo service is being served on {interface}")
     try:
         loop.run_forever()
     except KeyboardInterrupt:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     setup_requires=["pytest-runner" if TESTING else ""],
     tests_require=["pytest", "pytest-asyncio", "pytest-cov", "pytest-repeat"],
     license="GPLv3",
+    python_requires=">=3.5",
     classifiers=CLASSIFIERS,
     description="Asynchronous console and interfaces for asyncio",
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ README = open("README.rst").read()
 CLASSIFIERS = """\
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
@@ -25,7 +24,7 @@ setup(
     setup_requires=["pytest-runner" if TESTING else ""],
     tests_require=["pytest", "pytest-asyncio", "pytest-cov", "pytest-repeat"],
     license="GPLv3",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     classifiers=CLASSIFIERS,
     description="Asynchronous console and interfaces for asyncio",
     long_description=README,

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,11 @@ README = open("README.rst").read()
 CLASSIFIERS = """\
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3 :: Only
 """.splitlines()
 
 setup(
@@ -30,5 +31,5 @@ setup(
     author="Vincent Michel",
     author_email="vxgmichel@gmail.com",
     url="https://github.com/vxgmichel/aioconsole",
-    download_url="http://pypi.python.org/pypi/aioconsole",
+    download_url="https://pypi.org/project/aioconsole/",
 )

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -77,7 +77,7 @@ Try:
 
 def make_cli(streams=None):
     async def say_hello(reader, writer, name=None):
-        data = "Hello {}!".format(name) if name else "Hello!"
+        data = f"Hello {name}!" if name else "Hello!"
         writer.write(data.encode() + b"\n")
 
     parser = argparse.ArgumentParser(description="Say hello")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,8 +14,8 @@ async def test_server(event_loop):
 
     stream = io.StringIO()
     print_server(server, "test console", file=stream)
-    expected = "The test console is being served on 127.0.0.1:{}\n"
-    assert stream.getvalue() == expected.format(address[1])
+    expected = f"The test console is being served on 127.0.0.1:{address[1]}\n"
+    assert stream.getvalue() == expected
 
     reader, writer = await asyncio.open_connection(*address)
     assert (await reader.readline()) == b"test\n"
@@ -37,8 +37,8 @@ async def test_uds_server(event_loop, tmpdir):
 
     stream = io.StringIO()
     print_server(server, "test console", file=stream)
-    expected = "The test console is being served on {}\n"
-    assert stream.getvalue() == expected.format(path)
+    expected = f"The test console is being served on {path}\n"
+    assert stream.getvalue() == expected
 
     address = server.sockets[0].getsockname()
     reader, writer = await asyncio.open_unix_connection(address)


### PR DESCRIPTION
Python 3.4 was dropped in https://github.com/vxgmichel/aioconsole/pull/68, but there's a few extra places to update.

This also adds `python_requires` to help pip install the correct version for the user's running Python.

---

Python 3.5 is also EOL next weekend, maybe drop that too?

https://devguide.python.org/#status-of-python-branches

Here's the pip installs for aioconsole from PyPI for August 2020, showing very low numbers for 3.5 (and amazing to see such high numbers for a single version, 3.8!)

| category | percent | downloads  |
|----------|--------:|-----------:|
| 3.8      |  99.08% | 10,752,452 |
| null     |   0.84% |     91,463 |
| 3.7      |   0.05% |      5,204 |
| 3.6      |   0.03% |      3,127 |
| 3.5      |   0.00% |         43 |
| 2.7      |   0.00% |         34 |
| 3.9      |   0.00% |          9 |
| 3.4      |   0.00% |          5 |
| Total    |         | 10,852,337 |

Source: `pip install -U pypistats && pypistats python_minor aioconsole --last-month`