### PR TITLE
Fix async generator magic method definition

### DIFF
--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -109,7 +109,7 @@ class NonFileStreamReader:
         self.eof = not data
         return data
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -71,10 +71,8 @@ async def test_create_standard_stream_with_non_pipe():
 
     assert reader.at_eof() is False
 
-    assert (await reader.__aiter__()) == reader
-    assert (await reader.__anext__()) == b"d\n"
-    with pytest.raises(StopAsyncIteration):
-        await reader.__anext__()
+    async for data in reader:
+        assert data == b"d\n"
 
     assert reader.at_eof() is True
 


### PR DESCRIPTION
Allows you to use async generators like this:
```python
from asyncio import get_event_loop

from aioconsole.stream import get_standard_streams, aprint


async def main():
    reader, _ = await get_standard_streams()
    async for line in reader:
        await aprint(line.decode('utf-8'))


if __name__ == "__main__":
    loop = get_event_loop()
    loop.run_until_complete(main())
```