### PR TITLE
Fix `AttributeError: 'StandardStreamWriter' object has no attribute 'flush'` when using `aprint()` with `flush=True` 

### DIFF
--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -208,5 +208,8 @@ async def aprint(
     if streams is None:
         streams = await get_standard_streams(use_stderr=use_stderr, loop=loop)
     _, writer = streams
-    print(*values, sep=sep, end=end, flush=flush, file=writer)
-    await writer.drain()
+
+    print(*values, sep=sep, end=end, flush=False, file=writer)
+
+    if flush:
+        await writer.drain()

--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -210,7 +210,7 @@ async def ainput(prompt="", *, streams=None, use_stderr=False, loop=None):
 
 
 async def aprint(
-    *values, sep=None, end="\n", flush=False, streams=None, use_stderr=False, loop=None
+    *values, sep=None, end="\n", flush=True, streams=None, use_stderr=False, loop=None
 ):
     """Asynchronous equivalent to *print*."""
     # Get standard streams

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -77,13 +77,15 @@ async def test_create_standard_stream_with_non_pipe():
     assert reader.at_eof() is True
 
 
-@pytest.mark.asyncio
-async def test_ainput_with_standard_stream(monkeypatch):
-    string = "a\nb\n"
-    monkeypatch.setattr("sys.stdin", io.StringIO(string))
+def mock_stdio(monkeypatch, input_text=''):
+    monkeypatch.setattr("sys.stdin", io.StringIO(input_text))
     monkeypatch.setattr("sys.stdout", io.StringIO())
     monkeypatch.setattr("sys.stderr", io.StringIO())
 
+
+@pytest.mark.asyncio
+async def test_ainput_with_standard_stream(monkeypatch):
+    mock_stdio(monkeypatch, "a\nb\n")
     assert (await ainput()) == "a"
     assert (await ainput(">>> ")) == "b"
     assert sys.stdout.getvalue() == ">>> "
@@ -92,15 +94,20 @@ async def test_ainput_with_standard_stream(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_aprint_with_standard_stream(monkeypatch):
-    string = ""
-    monkeypatch.setattr("sys.stdin", io.StringIO())
-    monkeypatch.setattr("sys.stdout", io.StringIO(string))
-    monkeypatch.setattr("sys.stderr", io.StringIO())
+    mock_stdio(monkeypatch)
     await aprint("ab", "cd")
     assert sys.stdout.getvalue() == "ab cd\n"
     await aprint("a" * 1024 * 64)
     assert sys.stdout.getvalue() == "ab cd\n" + "a" * 1024 * 64 + "\n"
     assert sys.stderr.getvalue() == ""
+
+
+@pytest.mark.parametrize('flush', [False, True])
+@pytest.mark.asyncio
+async def test_aprint_with_flushing_stream(monkeypatch, flush):
+    mock_stdio(monkeypatch)
+    await aprint("a", flush=flush)
+    assert sys.stdout.getvalue() == "a\n"
 
 
 @pytest.mark.asyncio

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -77,7 +77,7 @@ async def test_create_standard_stream_with_non_pipe():
     assert reader.at_eof() is True
 
 
-def mock_stdio(monkeypatch, input_text=''):
+def mock_stdio(monkeypatch, input_text=""):
     monkeypatch.setattr("sys.stdin", io.StringIO(input_text))
     monkeypatch.setattr("sys.stdout", io.StringIO())
     monkeypatch.setattr("sys.stderr", io.StringIO())
@@ -102,7 +102,7 @@ async def test_aprint_with_standard_stream(monkeypatch):
     assert sys.stderr.getvalue() == ""
 
 
-@pytest.mark.parametrize('flush', [False, True])
+@pytest.mark.parametrize("flush", [False, True])
 @pytest.mark.asyncio
 async def test_aprint_with_flushing_stream(monkeypatch, flush):
     mock_stdio(monkeypatch)


### PR DESCRIPTION
Minimal reproducible example:
```python
import asyncio

from aioconsole import aprint


async def main():
    await aprint('Hello World!', flush=True)


asyncio.run(main())
```
Output:
```
Hello World!
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-c40141b81942> in <module>
      7
      8
----> 9 asyncio.run(main())

/usr/lib/python3.9/asyncio/runners.py in run(main, debug)
     42         if debug is not None:
     43             loop.set_debug(debug)
---> 44         return loop.run_until_complete(main)
     45     finally:
     46         try:

/usr/lib/python3.9/asyncio/base_events.py in run_until_complete(self, future)
    640             raise RuntimeError('Event loop stopped before Future completed.')
    641
--> 642         return future.result()
    643
    644     def stop(self):

<ipython-input-2-c40141b81942> in main()
      4
      5 async def main():
----> 6     await aprint('Hello World!', flush=True)
      7
      8

~/.local/lib/python3.9/site-packages/aioconsole/stream.py in aprint(sep, end, flush, streams, use_stderr, loop, *values)
    209         streams = await get_standard_streams(use_stderr=use_stderr, loop=loop)
    210     _, writer = streams
--> 211     print(*values, sep=sep, end=end, flush=flush, file=writer)
    212     await writer.drain()

AttributeError: 'StandardStreamWriter' object has no attribute 'flush'
```
