### PR TITLE
Prevent NonFileStreamWriter.write from blocking

### DIFF
--- a/aioconsole/compat.py
+++ b/aioconsole/compat.py
@@ -2,5 +2,5 @@
 
 import sys
 
-PY37 = sys.version_info >= (3, 7)
+PY36 = (3, 6) <= sys.version_info < (3, 7)
 platform = sys.platform

--- a/aioconsole/console.py
+++ b/aioconsole/console.py
@@ -27,7 +27,7 @@ try:
 except NameError:
     help_function = None
 
-current_task = asyncio.current_task if compat.PY37 else asyncio.Task.current_task
+current_task = asyncio.Task.current_task if compat.PY36 else asyncio.current_task
 
 
 class AsynchronousCompiler(codeop.CommandCompiler):

--- a/aioconsole/server.py
+++ b/aioconsole/server.py
@@ -36,7 +36,7 @@ async def start_interactive_server(
         start_server = partial(asyncio.start_unix_server, path=path)
 
     client_connected = partial(handle_connect, factory=factory, banner=banner)
-    server = await start_server(client_connected, loop=loop)
+    server = await start_server(client_connected)
     return server
 
 

--- a/aioconsole/stream.py
+++ b/aioconsole/stream.py
@@ -142,7 +142,7 @@ class NonFileStreamWriter:
         if self.write_task is not None and self.write_task.done():
             self.write_task = None
             self.task_finalizer()
-        self.write_task = asyncio.create_task(
+        self.write_task = asyncio.ensure_future(
             _nonfile_stream_writer_task_target(self.buffer, self.stream)
         )
         self.task_finalizer = weakref.finalize(self, self.write_task.result)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ description_file = README.rst
 license_files = LICENSE
 
 [tool:pytest]
-addopts = tests --strict --cov aioconsole --count 2
+addopts = tests --strict-markers --cov aioconsole --count 2
 
 [aliases]
 test = pytest

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -52,6 +52,7 @@ async def test_interact_simple(event_loop, monkeypatch):
     with stdcontrol(event_loop, monkeypatch) as (reader, writer):
         banner = "A BANNER"
         writer.write("1+1\n")
+        await writer.drain()
         writer.stream.close()
         await interact(banner=banner, stop=False)
         await assert_stream(reader, banner)
@@ -64,6 +65,7 @@ async def test_interact_traceback(event_loop, monkeypatch):
     with stdcontrol(event_loop, monkeypatch) as (reader, writer):
         banner = "A BANNER"
         writer.write("1/0\n")
+        await writer.drain()
         writer.stream.close()
         await interact(banner=banner, stop=False)
         # Check stderr
@@ -81,6 +83,7 @@ async def test_interact_traceback(event_loop, monkeypatch):
 async def test_interact_syntax_error(event_loop, monkeypatch):
     with stdcontrol(event_loop, monkeypatch) as (reader, writer):
         writer.write("a b\n")
+        await writer.drain()
         writer.stream.close()
         banner = "A BANNER"
         await interact(banner=banner, stop=False)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -24,7 +24,7 @@ async def test_server(event_loop):
     writer.write_eof()
     assert (await reader.readline()) == b">>> \n"
     writer.close()
-    if compat.PY37:
+    if not compat.PY36:
         await writer.wait_closed()
     server.close()
     await server.wait_closed()
@@ -55,7 +55,7 @@ async def test_uds_server(event_loop, tmpdir_factory):
     writer.write_eof()
     assert (await reader.readline()) == b">>> \n"
     writer.close()
-    if compat.PY37:
+    if not compat.PY36:
         await writer.wait_closed()
     server.close()
     await server.wait_closed()

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -104,9 +104,13 @@ async def test_aprint_with_standard_stream(monkeypatch):
 
 @pytest.mark.parametrize("flush", [False, True])
 @pytest.mark.asyncio
-async def test_aprint_with_flushing_stream(monkeypatch, flush):
+async def test_aprint_flush_argument(monkeypatch, flush):
     mock_stdio(monkeypatch)
     await aprint("a", flush=flush)
+    if not flush:
+        # Might or might not be there yet, depending on internal logic
+        assert sys.stdout.getvalue() in ("", "a\n")
+        await aprint("", end="", flush=True)
     assert sys.stdout.getvalue() == "a\n"
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -63,8 +63,17 @@ async def test_create_standard_stream_with_non_pipe():
     assert data == b"b\n"
     assert stderr.getvalue() == "b\n"
 
-    writer2.stream = Mock(spec={})
-    await writer2.drain()
+    # Multiple writes
+    writer2.write("c\n")
+    writer2.write("d\n")
+    await asyncio.sleep(0.1)
+    writer2.write("e\n")
+    writer2.close()
+    assert writer2.is_closing()
+    await writer2.wait_closed()
+    assert stderr.getvalue() == "b\nc\nd\ne\n"
+    with pytest.raises(RuntimeError):
+        writer2.write("f\n")
 
     data = await reader.read(2)
     assert data == b"c\n"


### PR DESCRIPTION
This is done by creating a task that runs the blocking write call in the default thread pool executor.

It also fixes a few warnings.