### PR TITLE
Added `eval`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Asynchronous console and interfaces for asyncio
 
 aioconsole_ provides:
 
-* asynchronous equivalents to `input`_, `print`_, `exec`_, `eval`, and `code.interact`_
+* asynchronous equivalents to `input`_, `print`_, `exec`_, `eval`_, and `code.interact`_
 * an interactive loop running the asynchronous python console
 * a way to customize and run command line interface using `argparse`_
 * `stream`_ support to serve interfaces instead of using standard streams
@@ -123,6 +123,7 @@ Vincent Michel: vxgmichel@gmail.com
 .. _input: https://docs.python.org/3/library/functions.html#input
 .. _print: https://docs.python.org/3/library/functions.html#print
 .. _exec: https://docs.python.org/3/library/functions.html#exec
+.. _eval: https://docs.python.org/3/library/functions.html#eval
 .. _code.interact: https://docs.python.org/3/library/code.html#code.interact
 .. _argparse: https://docs.python.org/dev/library/argparse.html
 .. _stream: https://docs.python.org/3/library/asyncio-stream.html

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Asynchronous console and interfaces for asyncio
 
 aioconsole_ provides:
 
-* asynchronous equivalents to `input`_, `print`_, `exec`_ and `code.interact`_
+* asynchronous equivalents to `input`_, `print`_, `exec`_, `eval`_, and `code.interact`_
 * an interactive loop running the asynchronous python console
 * a way to customize and run command line interface using `argparse`_
 * `stream`_ support to serve interfaces instead of using standard streams

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Asynchronous console and interfaces for asyncio
 
 aioconsole_ provides:
 
-* asynchronous equivalents to `input`_, `print`_, `exec`_, `eval`_, and `code.interact`_
+* asynchronous equivalents to `input`_, `print`_, `exec`_, `eval`, and `code.interact`_
 * an interactive loop running the asynchronous python console
 * a way to customize and run command line interface using `argparse`_
 * `stream`_ support to serve interfaces instead of using standard streams

--- a/aioconsole/__init__.py
+++ b/aioconsole/__init__.py
@@ -3,7 +3,7 @@
 It also includes an interactive event loop, and a command line interface.
 """
 
-from .execute import aexec
+from .execute import aexec, aeval
 from .console import AsynchronousConsole, interact
 from .stream import ainput, aprint, get_standard_streams
 from .events import InteractiveEventLoop, InteractiveEventLoopPolicy
@@ -14,6 +14,7 @@ from .apython import run_apython
 
 __all__ = [
     "aexec",
+    "aeval",
     "ainput",
     "aprint",
     "AsynchronousConsole",

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -78,12 +78,25 @@ async def aexec(source, local=None, stream=None):
 
     Support the *await* syntax.
     """
-    if local is None:
-        local = {}
+    local = local or {}
     if isinstance(source, str):
         source = compile_for_aexec(source)
     for tree in source:
         coro = make_coroutine_from_tree(tree, local=local)
         result, new_local = await coro
+        exec_result(result, new_local, stream)
+        full_update(local, new_local)
+
+async def aeval(source, local=None):
+    """Asynchronous equivalent to *eval*.
+
+    Support the *await* syntax.
+    """"
+    local = local or {}
+    if isinstance(source, str):
+        source = compile_for_aexec(source, filename="<aeval>")
+    for tree in source:
+        coro = make_coroutine_from_tree(tree, local=local, filename="<aeval>")
+        result, new_local = await Coro
         exec_result(result, new_local, stream)
         full_update(local, new_local)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Asynchronous console and interfaces for asyncio
 
 aioconsole_ provides:
 
-* asynchronous equivalents to `input`_, `exec`_ and `code.interact`_
+* asynchronous equivalents to `input`_, `exec`_ and `eval`_, `code.interact`_
 * an interactive loop running the asynchronous python console
 * a way to customize and run command line interface using `argparse`_
 * `stream`_ support to serve interfaces instead of using standard streams

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ Programming Language :: Python :: 3 :: Only
 
 setup(
     name="aioconsole",
-    version="0.3.2.dev0",
+    version="0.3.2.dev1",
     packages=["aioconsole"],
     entry_points={"console_scripts": ["apython = aioconsole:run_apython"]},
     setup_requires=["pytest-runner" if TESTING else ""],


### PR DESCRIPTION
I have added `eval` (aeval) to the library, it's just aexec, but soon enough I'll add a custom executor for `aeval`.