### PR TITLE
Ignore OSError after an EOFError in console.interact method

### DIFF
--- a/aioconsole/console.py
+++ b/aioconsole/console.py
@@ -192,8 +192,11 @@ class AsynchronousConsole(code.InteractiveConsole):
                 try:
                     line = await self.raw_input(prompt)
                 except EOFError:
-                    self.write("\n")
-                    await self.flush()
+                    try:
+                        self.write("\n")
+                        await self.flush()
+                    except OSError:
+                        pass
                     break
                 else:
                     more = await self.push(line)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -95,5 +95,4 @@ async def test_async_cli(event_loop, monkeypatch, input_string, expected):
     monkeypatch.setattr("sys.stdin", io.StringIO(input_string))
     monkeypatch.setattr("sys.stderr", io.StringIO())
     await make_cli().interact(stop=False)
-    print(sys.stderr.getvalue())
     assert sys.stderr.getvalue() == expected


### PR DESCRIPTION
Fix issue #87.