### PR TITLE
Improved console

### DIFF
--- a/aioconsole/console.py
+++ b/aioconsole/console.py
@@ -28,10 +28,15 @@ except NameError:
 
 
 class AsynchronousCompiler(codeop.CommandCompiler):
-    def __init__(self):
-        self.compiler = functools.partial(
-            execute.compile_for_aexec, dont_imply_dedent=True
-        )
+    def __call__(self, source, filename, symbol):
+        try:
+            code = super().__call__(source, filename, symbol)
+        except SyntaxError:
+            pass
+        else:
+            if code is None:
+                return None
+        return execute.compile_for_aexec(source, filename, symbol, True)
 
 
 class AsynchronousConsole(code.InteractiveConsole):

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -109,10 +109,10 @@ def compile_for_aexec(
         (" " * 4 if i not in non_indented and line else "") + line
         for i, line in enumerate(source.split("\n"))
     )
-    coroutine = CORO_DEF + "\n" + indented + "\n"
+    coroutine = CORO_DEF + "\n    pass\n" + indented + "\n"
     interactive = compile(coroutine, filename, mode, flags).body[0]
 
-    return [make_tree(statement, filename, mode) for statement in interactive.body]
+    return [make_tree(statement, filename, mode) for statement in interactive.body[1:]]
 
 
 async def aexec(source, local=None, stream=None):

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -52,6 +52,12 @@ async def test_incomplete_code():
         await aexec("(")
 
 
+@pytest.mark.asyncio
+async def test_unexpected_indent():
+    with pytest.raises(IndentationError):
+        await aexec(" 1")
+
+
 # Test return and yield handling
 
 

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -146,3 +146,15 @@ async def test_broken_pipe(event_loop, monkeypatch, signaling):
         await task
         # Test
         assert sys.stdout.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_interact_multiple_indented_lines(event_loop, monkeypatch):
+    with stdcontrol(event_loop, monkeypatch) as (reader, writer):
+        banner = "A BANNER"
+        writer.write("def x():\n    print(1)\n    print(2)\n\n")
+        await writer.drain()
+        writer.stream.close()
+        await interact(banner=banner, stop=False)
+        await assert_stream(reader, banner)
+        await assert_stream(reader, sys.ps1 + sys.ps2 * 3 + sys.ps1)


### PR DESCRIPTION
Hello, it's me again 😅
Here I've made two improvements:
# 1. Raise on unexpected indent
Now this raises an error, as (I think) it should:
```py
$ apython
>>>     print('a')
  File "<console>", line 3
    print('a')
IndentationError: unexpected indent
```
# 2. Allow multiple indented lines
Earlier the shell was working like this:
```py
>>> def x():
...     print(0)
>>>
```
And it was really irritating (at least for me).
But now it works almost like the default interactive shell:
```py
$ apython
>>> def x():
...     print(0)
...     print(1)
...
>>>
```
What is your opinion on this?