### PR TITLE
Handle both exec and single mode when compiling code for aexec

### DIFF
--- a/aioconsole/console.py
+++ b/aioconsole/console.py
@@ -107,7 +107,9 @@ class AsynchronousConsole(code.InteractiveConsole):
 
     async def runcode(self, code):
         try:
-            await execute.aexec(code, self.locals, self)
+            await execute.aexec(
+                code, local=self.locals, stream=self, filename=self.filename
+            )
         except SystemExit:
             raise
         except BaseException:

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -146,3 +146,15 @@ async def test_broken_pipe(event_loop, monkeypatch, signaling):
         await task
         # Test
         assert sys.stdout.getvalue() == ""
+
+
+@pytest.mark.asyncio
+async def test_interact_multiple_indented_lines(event_loop, monkeypatch):
+    with stdcontrol(event_loop, monkeypatch) as (reader, writer):
+        banner = "A BANNER"
+        writer.write("def x():\n    print(1)\n    print(2)\n\nx()\n")
+        await writer.drain()
+        writer.stream.close()
+        await interact(banner=banner, stop=False)
+        await assert_stream(reader, banner)
+        await assert_stream(reader, sys.ps1 + sys.ps2 * 3 + sys.ps1 + "1\n2")


### PR DESCRIPTION
In particular this means that `await aexec("1")` will no longer print to stdout (similar to `exec("1")`).

Also fixes a regression introduced in commit c2dac60d3c2922bbb927021004c0dca251bda1ba in version `0.4.0`.

This caused multi-line statements to be handle incorrectly:
```python
>>> def f():
...     return 1
>>>
```
Instead of 
```python
>>> def f():
...     return 1
...
>>>
```
