### PR TITLE
Added return value notation to ainput

### DIFF
--- a/aioconsole/console.py
+++ b/aioconsole/console.py
@@ -76,7 +76,7 @@ class AsynchronousConsole(code.InteractiveConsole):
         self.print(pydoc.render_doc(obj))
 
     @functools.wraps(stream.ainput)
-    async def ainput(self, prompt="", *, streams=None, use_stderr=False, loop=None):
+    async def ainput(self, prompt="", *, streams=None, use_stderr=False, loop=None) -> str:
         # Get the console streams by default
         if streams is None and use_stderr is False:
             streams = self.reader, self.writer


### PR DESCRIPTION
ainput() returns a string, we should note that in the function declaration.