### PR TITLE
Add aeval: Asynchronous Equivalent to eval in aioconsole

### DIFF
--- a/aioconsole/__init__.py
+++ b/aioconsole/__init__.py
@@ -3,7 +3,7 @@
 It also includes an interactive event loop, and a command line interface.
 """
 
-from .execute import aexec
+from .execute import aexec, aeval
 from .console import AsynchronousConsole, interact
 from .stream import ainput, aprint, get_standard_streams
 from .events import InteractiveEventLoop, InteractiveEventLoopPolicy
@@ -17,6 +17,7 @@ __version__ = "0.7.2.dev0"
 
 __all__ = [
     "aexec",
+    "aeval",
     "ainput",
     "aprint",
     "AsynchronousConsole",

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -158,9 +158,10 @@ async def aeval(source, local=None):
     if not isinstance(local, dict):
         raise TypeError("globals must be a dict")
 
-    key = "__result__"
     # Ensure that the result key is unique within the local namespace
-    # while key in local: key += "_"
+    key = "__aeval_result__"
+    while key in local:
+        key += "_"
 
     # Perform syntax check to ensure the input is a valid eval expression
     try:

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -151,25 +151,25 @@ async def aexec(source, local=None, stream=None, filename="<aexec>"):
         full_update(local, new_local)
 
 
-async def aeval(input_string: str, local_namespace: dict = None):
-    """Asynchronous equivalent to *eval* that evaluates expressions."""
-    if local_namespace is None:
-        local_namespace = {}
+async def aeval(source, local=None):
+    """Asynchronous equivalent to *eval*."""
+    if local is None:
+        local = {}
 
     # Perform syntax check to ensure the input is a valid eval expression
     try:
-        ast.parse(input_string, mode="eval")
+        ast.parse(source, mode="eval")
     except SyntaxError:
         raise
 
-    # Use aexec to execute the input string within an async function context
-    wrapped_code = f"__result__ = {input_string}"
+    # Assign the result of the expression to a known variable
+    wrapped_code = f"__aeval_result__ = {source}"
 
     # Use aexec to evaluate the wrapped code within the given local namespace
-    await aexec(wrapped_code, local=local_namespace)
+    await aexec(wrapped_code, local=local)
 
     # Retrieve the result from the local namespace
-    result = local_namespace.get("__result__")
+    result = local.get("__aeval_result__")
     if asyncio.iscoroutine(result):
         result = await result
 

--- a/aioconsole/execute.py
+++ b/aioconsole/execute.py
@@ -151,41 +151,26 @@ async def aexec(source, local=None, stream=None, filename="<aexec>"):
         full_update(local, new_local)
 
 
-async def aeval(input_string: str, local_namespace: dict):
-    """Asynchronous equivalent to *eval*."""
-    # Save the state of the local namespace before executing the code
-    previous = {k: v for k, v in local_namespace.items()}
+async def aeval(input_string: str, local_namespace: dict = None):
+    """Asynchronous equivalent to *eval* that evaluates expressions."""
+    if local_namespace is None:
+        local_namespace = {}
 
-    # Split the input string by lines to handle multiline input
-    lines = input_string.splitlines()
+    # Perform syntax check to ensure the input is a valid eval expression
+    try:
+        ast.parse(input_string, mode="eval")
+    except SyntaxError:
+        raise
 
-    for i, line in enumerate(lines):
-        # Capture the result of the expression in a special variable '__result__'
-        if i == len(lines) - 1:
-            # Only modify the last line to capture the final result
-            modified_input = f"__result__ = {line}"
-        else:
-            modified_input = line
+    # Use aexec to execute the input string within an async function context
+    wrapped_code = f"__result__ = {input_string}"
 
-        try:
-            # Try to execute the modified input to capture the result in '__result__'
-            await aexec(modified_input, local_namespace)
-        except SyntaxError:
-            # This might be a statement rather than an expression.
-            # In this case, execute the original input without modification.
-            await aexec(line, local_namespace)
+    # Use aexec to evaluate the wrapped code within the given local namespace
+    await aexec(wrapped_code, local=local_namespace)
 
-    # Attempt to retrieve the result of the expression from the local namespace
-    result = local_namespace.pop("__result__", None)
-
-    # Capture the state of the local namespace after execution
-    post = {k: v for k, v in local_namespace.items()}
-
-    # Check if the local namespace has changed.
-    # If not, the code might have been a statement rather than an expression
-    if previous == post:
-        # The result is a coroutine and wasn't assigned to a variable, await its result
-        if asyncio.iscoroutine(result) and result not in local_namespace.values():
-            result = await result
+    # Retrieve the result from the local namespace
+    result = local_namespace.get("__result__")
+    if asyncio.iscoroutine(result):
+        result = await result
 
     return result

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -243,3 +243,11 @@ async def test_aeval_valid_await_syntax():
     local = {"aecho": aecho}
     result = await aeval(expression, local)
     assert result == 10
+
+
+@pytest.mark.asyncio
+async def test_aeval_coro_in_local():
+    expression = "await coro"
+    local = {"coro": aecho(10)}
+    result = await aeval(expression, local)
+    assert result == 10

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -199,6 +199,8 @@ async def aecho(x):
         (asyncio, None),
         (..., None),
         (lambda: ..., None),
+        # Conflicting name in local
+        ("x", {"x": 1, "__aeval_result__": 99}),
     ],
 )
 async def test_aeval(expression, local):


### PR DESCRIPTION
This PR introduces a new `aeval` function to the `aioconsole` library, providing an asynchronous equivalent to Python's built-in `eval`. The `aeval` function enhances `aioconsole` by enabling users to evaluate expressions asynchronously within an interactive console environment, complementing the existing `aexec` function.

### Key Features of `aeval`:

**Asynchronous Evaluation:**
- The `aeval` function allows for the evaluation of expressions that may involve asynchronous operations. This is particularly useful in environments where asynchronous code is prevalent, such as web servers or other I/O-bound applications.

**Behavior Consistent with `eval`:**
- `aeval` functions in a manner consistent with Python’s built-in `eval`. It evaluates single-line expressions and raises the same exceptions as `eval` for invalid input.
- Notably, `aeval` does **not** handle multi-line inputs or statements (e.g., function definitions, loops), maintaining strict compatibility with the `eval` behavior which is limited to single expressions.

**Error Handling:**
- The function gracefully handles syntax errors and other exceptions, providing clear feedback when issues arise during the evaluation of expressions, just as `eval` does.

**Seamless Integration with Existing `aexec`:**
- The implementation of `aeval` builds upon the `aexec` function, ensuring consistent behavior and making use of the existing compilation and execution mechanisms within `aioconsole`.

### Example Usage:

```python
import asyncio
from aioconsole import aeval

async def main():
    local_namespace = {"x": 10}
    result = await aeval("x + 5", local_namespace)
    print(result)  # Outputs: 15

asyncio.run(main())
```

This PR ensures that `aeval` behaves exactly like the built-in `eval`, with the added capability of handling asynchronous functions, making it a powerful tool for asynchronous interactive environments.