### PR TITLE
Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "aioconsole"
 dynamic = ["version"]
 description = "Asynchronous console and interfaces for asyncio"
 readme = {file = "README.rst", content-type = "text/x-rst"}
-license = {file = "LICENSE"}
+license = {text = "GPL-3.0-or-later"}
 requires-python = ">=3.8"
 authors = [
     { name = "Vincent Michel", email = "vxgmichel@gmail.com" },


### PR DESCRIPTION
Use the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/GPL-3.0-or-later.html

https://github.com/vxgmichel/aioconsole/blob/cfca2d3e0bfe06a094ff3a9d43abd1b97675eeeb/LICENSE#L637-L640